### PR TITLE
Development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [2.3.0]
+
+### Added
+- ClickHouse backend support via `clickhouse-connect` HTTP client
+  - `ClickHouseConnection` — connection wrapper with DB-API 2.0 compatible cursor and client wrappers
+  - `ClickHouseRepository` — repository with ClickHouse mutation syntax (`ALTER TABLE ... UPDATE/DELETE`)
+  - `ClickHouseManager` — database introspection using `system.*` tables
+  - `ClickHouseMigrationManager` — forward-only migration manager for ClickHouse
+  - `ClickHouseUpdate` / `ClickHouseDelete` — SQL builders generating ClickHouse mutation syntax
+  - `ClickHouseSqlDialect` — dialect with ClickHouse-specific placeholders, JSON functions, and no `INSERT...RETURNING`
+- ClickHouse integration tests using `tox-docker` with `clickhouse/clickhouse-server:25.8`
+- `clickhouse-connect>=0.7.0` added to dev dependencies
+
+### Changed
+- Updated `tox.ini` to include ClickHouse docker service alongside PostgreSQL
+
+### Security
+- **sql/dialect.py**: Fixed SQL identifier quoting across all dialects (PostgreSQL, SQLite, ClickHouse) to escape embedded double-quotes by doubling them (SQL standard). Previously, `dialect.table()`, `dialect.field()`, and `dialect.database()` wrapped names in double-quotes without escaping, allowing identifier injection in Manager DDL methods (`create_database`, `drop_database`, `drop_table`, `drop_view`)
+
 ## [2.2.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.2.0]
+
+### Added
+- `json_exclude` parameter on `@fieldmapper` decorator to exclude fields from `asdict()` serialization at the class level
+- `exclude` parameter on `asdict()` for per-call field exclusion, merged with class-level defaults
+- Excluded fields remain accessible via attribute access, `asrecord()`, `fields()`, and `values()`
+
 ## [2.1.0]
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 SQL database abstraction layer for Python. **Not an ORM** — follows a schema-first approach where the database structure is managed independently via SQL DDL.
 
-Supports **PostgreSQL** (psycopg2) and **SQLite3**.
+Supports **PostgreSQL** (psycopg2), **SQLite3**, and **ClickHouse** (clickhouse-connect).
 
 ## Quick Start
 
@@ -38,6 +38,11 @@ from rick_db.backend.sqlite import Sqlite3Connection
 
 conn = Sqlite3Connection("mydb.db")       # file-based
 conn = Sqlite3Connection(":memory:")       # in-memory
+
+# ClickHouse
+from rick_db.backend.clickhouse import ClickHouseConnection
+
+conn = ClickHouseConnection(host="localhost", port=8123, database="mydb")
 ```
 
 ### Use the Repository
@@ -210,6 +215,13 @@ from rick_db.backend.sqlite import Sqlite3Manager
 
 mgr = Sqlite3Manager(conn)
 mgr.tables(), mgr.views(), mgr.table_fields("users"), mgr.table_pk("users")
+
+# ClickHouse
+from rick_db.backend.clickhouse import ClickHouseManager
+
+mgr = ClickHouseManager(conn)
+mgr.tables(), mgr.views(), mgr.table_fields("users"), mgr.table_pk("users")
+mgr.databases(), mgr.users()
 ```
 
 ## Profiler

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ and a Repository pattern implementation. It is **not** an ORM, and it's not mean
 ## Features
 - Object Mapper;
 - Fluent Sql Query builder;
-- High level connectors for PostgreSQL, SqlLite3;
+- High level connectors for PostgreSQL, SQLite3, ClickHouse;
 - Pluggable SQL query profiler; 
 - Simple migration manager for SQL files;
 
@@ -151,8 +151,8 @@ if __name__ == '__main__':
 ## Running tests
 
 To run the tests, you should have both tox and tox-docker, as well as a local docker daemon. Make sure the current user has
-access to the docker daemon.
+access to the docker daemon. The test suite uses PostgreSQL and ClickHouse docker containers.
 ```python
 $ pip3 install -r requirements-dev.txt
-$ tox 
+$ tox
 ```

--- a/docs/building_queries.md
+++ b/docs/building_queries.md
@@ -159,7 +159,7 @@ print(qry)
 ```python
 from rick_db.sql import Select, PgSqlDialect
 
-# LEFT JOIN
+# INNER JOIN
 qry, values = (
     Select(PgSqlDialect())
     .from_("table1")

--- a/docs/classes/clickhousemanager.md
+++ b/docs/classes/clickhousemanager.md
@@ -1,0 +1,17 @@
+# Class rick_db.backend.clickhouse.**ClickHouseManager**
+
+This class extends [ManagerInterface](managerinterface.md) to provide a specific ClickHouse implementation.
+It uses ClickHouse `system.*` tables for introspection. The `schema` parameter maps to ClickHouse `database`;
+when `None`, the connection's current database is used.
+
+The following methods are **NOT** supported, and either return empty lists or raise a *NotImplementedError* exception:
+
+- ClickHouseManager.user_groups()
+- ClickHouseManager.create_schema()
+- ClickHouseManager.drop_schema()
+- ClickHouseManager.kill_clients()
+
+The following methods delegate to their database equivalents (ClickHouse databases are equivalent to schemas):
+
+- ClickHouseManager.schemas() — delegates to databases()
+- ClickHouseManager.schema_exists() — delegates to database_exists()

--- a/docs/classes/jsonfield.md
+++ b/docs/classes/jsonfield.md
@@ -1,0 +1,145 @@
+# Class rick_db.sql.**JsonField**
+
+Specialized class for working with JSON/JSONB fields in SQL queries. Generates SQL expressions as `Literal` objects
+that can be used in `Select`, `where()`, and other query builder methods.
+
+When a dialect with `json_support` is provided, dialect-specific operators are used. Otherwise, generic `JSON_EXTRACT()`
+/ `JSON_CONTAINS()` syntax is generated as fallback.
+
+See also: [PgJsonField](pgjsonfield.md) for PostgreSQL-specific extensions, and [JSON Operations](../json_operations.md)
+for usage examples.
+
+### JsonField.**\_\_init\_\_(field_name, dialect=None)**
+
+Create a JsonField for the given *field_name*. An optional *dialect* can be provided to enable dialect-specific SQL
+generation.
+
+```python
+from rick_db.sql import JsonField
+from rick_db.sql.dialect import PgSqlDialect
+
+# Without dialect (generic SQL)
+jf = JsonField('data')
+
+# With PostgreSQL dialect
+jf = JsonField('data', PgSqlDialect())
+```
+
+### JsonField.**extract(path, alias=None)**
+
+Extract a value from the JSON field. Returns a `Literal` SQL expression.
+
+- *path* - JSON path or key name to extract
+- *alias* - optional alias for the result
+
+```python
+from rick_db.sql import JsonField
+from rick_db.sql.dialect import PgSqlDialect
+
+pg = PgSqlDialect()
+jf = JsonField('data', pg)
+
+expr = jf.extract('name')
+# output: "data"->>'name'
+print(expr)
+
+expr = jf.extract('name', 'user_name')
+# output: "data"->>'name' AS "user_name"
+print(expr)
+```
+
+Without a dialect:
+```python
+from rick_db.sql import JsonField
+
+jf = JsonField('data')
+
+expr = jf.extract('$.name')
+# output: JSON_EXTRACT(data, '$.name')
+print(expr)
+```
+
+### JsonField.**extract_text(path, alias=None)**
+
+Extract a value as text from the JSON field. Returns a `Literal` SQL expression.
+For PostgreSQL, this produces the same output as `extract()` (both use the `->>` operator).
+
+- *path* - JSON path or key name to extract
+- *alias* - optional alias for the result
+
+```python
+from rick_db.sql import JsonField
+from rick_db.sql.dialect import PgSqlDialect
+
+pg = PgSqlDialect()
+jf = JsonField('data', pg)
+
+expr = jf.extract_text('email', 'user_email')
+# output: "data"->>'email' AS "user_email"
+print(expr)
+```
+
+### JsonField.**contains(value)**
+
+Check if the JSON field contains a value. Returns a `Literal` SQL expression with a parameter placeholder.
+The *value* argument is not interpolated into the SQL; it should be passed separately for parameter binding.
+
+- *value* - value to check for (used for parameter binding)
+
+```python
+from rick_db.sql import JsonField
+from rick_db.sql.dialect import PgSqlDialect
+
+pg = PgSqlDialect()
+jf = JsonField('data', pg)
+
+expr = jf.contains('test')
+# output: "data" @> %s::jsonb
+print(expr)
+```
+
+### JsonField.**has_path(path)**
+
+Check if a path exists in the JSON field. Returns a `Literal` SQL expression.
+
+- *path* - path to check for existence
+
+```python
+from rick_db.sql import JsonField
+from rick_db.sql.dialect import PgSqlDialect
+
+pg = PgSqlDialect()
+jf = JsonField('data', pg)
+
+expr = jf.has_path('name')
+# output: "data" ?? 'name'
+print(expr)
+```
+
+### JsonField.**\_\_getitem\_\_(key)**
+
+Bracket notation for JSON path access. Returns a new `JsonField` representing the nested path.
+
+Uses the `->>` operator to build the path expression.
+
+```python
+from rick_db.sql import JsonField
+
+jf = JsonField('data')
+
+nested = jf['name']
+# output: data->>"name"
+print(nested)
+```
+
+### JsonField.**\_\_str\_\_()**
+
+Returns the field name string.
+
+```python
+from rick_db.sql import JsonField
+
+jf = JsonField('data')
+# output: data
+print(jf)
+```

--- a/docs/classes/managerinterface.md
+++ b/docs/classes/managerinterface.md
@@ -1,7 +1,7 @@
 # Class rick_db.**ManagerInterface**
 
-The ManagerInterface provides a common interface to [PgManager](pgmanager.md) and [Sqlite3Manager](sqlite3manager.md) 
-classes, exposing common management methods.
+The ManagerInterface provides a common interface to [PgManager](pgmanager.md), [Sqlite3Manager](sqlite3manager.md),
+and [ClickHouseManager](clickhousemanager.md) classes, exposing common management methods.
 
 ### ManagerInterface.**conn()**
 

--- a/docs/classes/pgjsonfield.md
+++ b/docs/classes/pgjsonfield.md
@@ -1,0 +1,199 @@
+# Class rick_db.sql.**PgJsonField**
+
+PostgreSQL-specific JSON field implementation that extends [JsonField](jsonfield.md) with additional operations
+for JSONB columns, including object extraction, jsonpath queries, and type casting.
+
+See also: [JSON Operations](../json_operations.md) for usage examples.
+
+### PgJsonField.**\_\_init\_\_(field_name, dialect=None, is_jsonb=True)**
+
+Create a PgJsonField for the given *field_name*. An optional *dialect* enables dialect-specific SQL generation.
+*is_jsonb* controls whether the field is treated as JSONB (default) or JSON.
+
+```python
+from rick_db.sql import PgJsonField
+from rick_db.sql.dialect import PgSqlDialect
+
+pg = PgSqlDialect()
+
+# JSONB field (default)
+jf = PgJsonField('data', pg)
+
+# JSON field
+jf = PgJsonField('data', pg, is_jsonb=False)
+```
+
+### PgJsonField.**extract(path, alias=None)**
+
+*Inherited from [JsonField](jsonfield.md).* Extract a value as text using the `->>` operator.
+
+```python
+from rick_db.sql import PgJsonField
+from rick_db.sql.dialect import PgSqlDialect
+
+pg = PgSqlDialect()
+jf = PgJsonField('data', pg)
+
+expr = jf.extract('name')
+# output: "data"->>'name'
+print(expr)
+
+expr = jf.extract('name', 'user_name')
+# output: "data"->>'name' AS "user_name"
+print(expr)
+
+# Numeric index for array access
+jf_tags = PgJsonField('tags', pg)
+expr = jf_tags.extract(0)
+# output: "tags"->>0
+print(expr)
+```
+
+### PgJsonField.**extract_text(path, alias=None)**
+
+*Inherited from [JsonField](jsonfield.md).* Extract a value as text. For PostgreSQL, produces the same output
+as `extract()`.
+
+### PgJsonField.**extract_object(path, alias=None)**
+
+Extract a JSON object using the `->` operator. Unlike `extract()` / `extract_text()`, this preserves the JSON type
+in the result.
+
+- *path* - key name or array index
+- *alias* - optional alias for the result
+
+```python
+from rick_db.sql import PgJsonField
+from rick_db.sql.dialect import PgSqlDialect
+
+pg = PgSqlDialect()
+jf = PgJsonField('data', pg)
+
+expr = jf.extract_object('config')
+# output: "data"->'config'
+print(expr)
+
+expr = jf.extract_object('config', 'cfg')
+# output: "data"->'config' AS "cfg"
+print(expr)
+```
+
+### PgJsonField.**path_query(path, alias=None)**
+
+PostgreSQL jsonpath query using the `@?` operator (requires PostgreSQL 12+).
+
+- *path* - jsonpath expression
+- *alias* - optional alias for the result
+
+```python
+from rick_db.sql import PgJsonField
+from rick_db.sql.dialect import PgSqlDialect
+
+pg = PgSqlDialect()
+jf = PgJsonField('data', pg)
+
+expr = jf.path_query('$.name')
+# output: "data"::jsonb @? '$.name'
+print(expr)
+```
+
+### PgJsonField.**as_jsonb()**
+
+Set the field type to JSONB. Affects the type cast suffix in `__str__()`. Returns `self`.
+
+### PgJsonField.**as_json()**
+
+Set the field type to JSON. Affects the type cast suffix in `__str__()`. Returns `self`.
+
+```python
+from rick_db.sql import PgJsonField
+from rick_db.sql.dialect import PgSqlDialect
+
+pg = PgSqlDialect()
+jf = PgJsonField('data', pg)
+
+# Default is JSONB
+# output: data::jsonb
+print(jf)
+
+jf.as_json()
+# output: data::json
+print(jf)
+
+jf.as_jsonb()
+# output: data::jsonb
+print(jf)
+```
+
+### PgJsonField.**contains(value)**
+
+*Inherited from [JsonField](jsonfield.md).* Check if the JSONB field contains a value using the `@>` operator.
+
+```python
+from rick_db.sql import PgJsonField
+from rick_db.sql.dialect import PgSqlDialect
+
+pg = PgSqlDialect()
+jf = PgJsonField('data', pg)
+
+expr = jf.contains('test')
+# output: "data" @> %s::jsonb
+print(expr)
+```
+
+### PgJsonField.**has_path(path)**
+
+*Inherited from [JsonField](jsonfield.md).* Check if a key exists using the `??` operator.
+
+```python
+from rick_db.sql import PgJsonField
+from rick_db.sql.dialect import PgSqlDialect
+
+pg = PgSqlDialect()
+jf = PgJsonField('data', pg)
+
+expr = jf.has_path('name')
+# output: "data" ?? 'name'
+print(expr)
+```
+
+### PgJsonField.**\_\_getitem\_\_(key)**
+
+Bracket notation using the `->` operator (preserves JSON type). Returns a new `PgJsonField`.
+
+```python
+from rick_db.sql import PgJsonField
+from rick_db.sql.dialect import PgSqlDialect
+
+pg = PgSqlDialect()
+jf = PgJsonField('data', pg)
+
+# Single level
+nested = jf['address']
+# output: data->"address"::jsonb
+print(nested)
+
+# Nested access
+nested = jf['address']['city']
+# output: data->"address"->"city"::jsonb
+print(nested)
+```
+
+### PgJsonField.**\_\_str\_\_()**
+
+Returns the field name with a type cast suffix (`::jsonb` or `::json`).
+
+```python
+from rick_db.sql import PgJsonField
+from rick_db.sql.dialect import PgSqlDialect
+
+pg = PgSqlDialect()
+
+jf = PgJsonField('data', pg)
+# output: data::jsonb
+print(jf)
+
+jf = PgJsonField('data', pg, is_jsonb=False)
+# output: data::json
+print(jf)
+```

--- a/docs/classes/select.md
+++ b/docs/classes/select.md
@@ -79,7 +79,7 @@ qry, _ = Select(PgSqlDialect()).from_("foo", ["field1", "field2"]).assemble()
 print(qry)
 
 qry, _ = Select(PgSqlDialect()).from_({"foo": "bar"}, ["field1"]).assemble()
-# output: SELECT "bar.field1" FROM "foo" AS "bar"
+# output: SELECT "bar"."field1" FROM "foo" AS "bar"
 print(qry)
 
 qry, _ = Select(PgSqlDialect()).from_(record_class_or_object, ["field1"]).assemble()
@@ -132,7 +132,7 @@ qry, _ = Select(PgSqlDialect()).from_("foo").page(1, 10).assemble()
 print(qry)
 
 qry, _ = Select(PgSqlDialect()).from_("foo").page(10, 10).assemble()
-# output: SELECT "foo".* FROM "foo" LIMIT 10 OFFSET 10
+# output: SELECT "foo".* FROM "foo" LIMIT 10 OFFSET 90
 print(qry)
 ```
 
@@ -148,11 +148,11 @@ Example:
 
 ```python
 qry, _ = Select(PgSqlDialect()).from_("foo").order('id').assemble()
-# output: SELECT "foo".* FROM "foo" ORDER BY id ASC
+# output: SELECT "foo".* FROM "foo" ORDER BY "id" ASC
 print(qry)
 
 qry, _ = Select(PgSqlDialect()).from_("foo").order(['id', 'name'], Select.ORDER_DESC).assemble()
-# output: SELECT "foo".* FROM "foo" ORDER BY id DESC, a DESC
+# output: SELECT "foo".* FROM "foo" ORDER BY "id" DESC,"name" DESC
 print(qry)
 ```
 
@@ -810,10 +810,64 @@ qry = (
 )
 
 # output:
-# SELECT "w".* FROM "wishlist" AS "w" 
+# SELECT "w".* FROM "wishlist" AS "w"
 #   LEFT JOIN LATERAL (
 #     SELECT "p".* FROM "product" AS "p" WHERE (price<desired_price) ORDER BY "price" DESC LIMIT 3
 #   ) AS "x" ON (true)
 # ORDER BY "wishlist_id" DESC,"price" DESC
 print(qry.assemble())
+```
+
+### Select.**json_field(field_name, table=None)**
+
+Creates a [JsonField](jsonfield.md) or [PgJsonField](pgjsonfield.md) instance bound to this query's dialect.
+If the dialect is `PgSqlDialect`, a `PgJsonField` is returned; otherwise a `JsonField` is returned.
+
+- *field_name* - the name of the JSON column
+- *table* - optional table name or alias to qualify the field
+
+```python
+pg = PgSqlDialect()
+qry = Select(pg).from_('users')
+
+# Creates a PgJsonField for the 'profile' column
+jf = qry.json_field('profile')
+
+# With table qualifier
+jf = qry.json_field('config', 'users')
+```
+
+For more details on JSON operations, see the [JSON Operations](../json_operations.md) guide.
+
+### Select.**json_extract(json_field, json_path, alias=None)**
+
+Adds a JSON extraction expression to the **SELECT** column list.
+
+- *json_field* - JSON field name (string) or `JsonField` object
+- *json_path* - JSON path or key to extract
+- *alias* - optional alias for the result column
+
+```python
+qry = Select(PgSqlDialect()).from_('users').json_extract('user_data', 'name', 'user_name')
+sql, _ = qry.assemble()
+# output: SELECT "users".*,"user_data"->>'name' AS "user_name" FROM "users"
+print(sql)
+```
+
+### Select.**json_where(json_field, json_path, operator, value=None)**
+
+Adds a **WHERE** condition for a JSON field value.
+
+- *json_field* - JSON field name (string) or `JsonField` object
+- *json_path* - JSON path or key to extract for comparison
+- *operator* - comparison operator
+- *value* - optional value to compare against
+
+```python
+qry = Select(PgSqlDialect()).from_('users').json_where('user_data', 'active', '=', True)
+sql, values = qry.assemble()
+# output: SELECT "users".* FROM "users" WHERE ("user_data"->>'active' = %s)
+print(sql)
+# values: [True]
+print(values)
 ```

--- a/docs/classes/sqldialect.md
+++ b/docs/classes/sqldialect.md
@@ -2,6 +2,12 @@
 
 Base Dialect Class. Implements schema, table and field quoting specifics to be used primarily within the query builder.
 
+Available dialect implementations:
+
+- **PgSqlDialect** — PostgreSQL dialect (`%s` placeholders, `INSERT...RETURNING`, `ILIKE`, JSONB operators)
+- **Sqlite3SqlDialect** — SQLite3 dialect (`?` placeholders, no `ILIKE`, no JSON)
+- **ClickHouseSqlDialect** — ClickHouse dialect (`%s` placeholders, no `INSERT...RETURNING`, `ILIKE`, JSON functions via `JSONExtractString`/`JSONHas`/`JSON_EXISTS`)
+
 ### SqlDialect.**table(table_name, alias=None, schema=None)**
 
 Quotes a table name, with an optional *alias* and *schema*.

--- a/docs/classes/update.md
+++ b/docs/classes/update.md
@@ -48,7 +48,7 @@ print(sql)
 
 ### Update.**values(values: Union[list, dict, object])**
 
-Define values of fields to be updated. This method can be called multiple times (see [fields()](insert.md/#insertfieldsfields-list) for an
+Define values of fields to be updated. This method can be called multiple times (see [fields()](insert.md#insertfieldsfields-list) for an
 example). If *values* is a dict, both fields and values are read from the provided dict. If *values* is a [Record](record.md)
 object, fields and values are read from the object.
 

--- a/docs/classes/with.md
+++ b/docs/classes/with.md
@@ -21,10 +21,12 @@ union = Select().union([
 ], Sql.UNION_ALL)
 
 # assemble a recursive CTE
-with_qry = With()
+with_qry = (
+    With()
     .clause("t", union)
     .query(Select().from_("t", cols={Literal("SUM(n)"): "total"}))
     .recursive()
+)
 
 sql, values = with_qry.assemble()
 # sql: WITH RECURSIVE "t"("n") AS (VALUES(1) UNION SELECT n+1 FROM "t" WHERE ("n" < %s)) SELECT SUM(n) AS "total" FROM "t"

--- a/docs/connection.md
+++ b/docs/connection.md
@@ -133,7 +133,7 @@ db_cfg = {
 }
 
 pool = PgConnectionPool(**db_cfg)
-# instantiate profiler, and use it on conn object
+# instantiate profiler, and use it on pool object
 pool.profiler = DefaultProfiler()
 
 # perform some queries we can profile
@@ -142,6 +142,6 @@ with pool.connection() as conn:
         c.exec("SELECT 1")
 
 # output: SELECT 1 0.00012579001486301422
-for evt in conn.profiler.get_events():
+for evt in pool.profiler.get_events():
     print(evt.query, evt.elapsed)
 ```

--- a/docs/connection.md
+++ b/docs/connection.md
@@ -88,6 +88,51 @@ with conn.cursor() as c:
     pass
 ```
 
+## Connecting to ClickHouse
+
+ClickHouse is supported via the `clickhouse-connect` HTTP client. Install the optional dependency:
+
+```shell
+$ pip install clickhouse-connect
+```
+
+Available connection parameters:
+
+|Field| Description |
+|---|---|
+|host| ClickHouse server hostname (defaults to "localhost") |
+|port| HTTP port (defaults to 8123) |
+|username| User name used to authenticate (defaults to "default") |
+|password| Password used to authenticate (defaults to empty) |
+|database| Database name (defaults to "default") |
+
+Any additional keyword arguments are passed directly to `clickhouse_connect.get_client()`.
+
+Example:
+```python
+from rick_db.backend.clickhouse import ClickHouseConnection
+
+config = {
+    'host': 'localhost',
+    'port': 8123,
+    'username': 'default',
+    'password': '',
+    'database': 'my_database',
+}
+
+# create connection
+conn = ClickHouseConnection(**config)
+with conn.cursor() as c:
+    # do stuff
+    pass
+```
+
+> Note: ClickHouse has no real transactions. `commit()` and `rollback()` are no-ops. The `Repository.transaction()`
+> context manager will work without errors but provides no atomicity guarantees. Each statement is its own unit of work.
+
+> Note: ClickHouse does not support `INSERT...RETURNING` or auto-increment primary keys. `insert_pk()` always returns
+> `None`. UPDATE and DELETE operations use ClickHouse mutation syntax (`ALTER TABLE ... UPDATE/DELETE`).
+
 ## Using a profiler
 
 RickDb provides a simple profiler interface that allows logging of queries, parameters and execution times, as well

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ and a Repository pattern implementation.
 - Object Mapper
 - Fluent SQL Query builder with schema support
 - Comprehensive JSON operations support
-- High level connectors for PostgreSQL, SQLite
+- High level connectors for PostgreSQL, SQLite, ClickHouse
 - Pluggable SQL query profiler
 - Grid helper
 - Migration Manager

--- a/docs/install.md
+++ b/docs/install.md
@@ -10,6 +10,10 @@ RickDb requires the following dependencies:
 - toml
 - setuptools
 
+For ClickHouse support, install the optional `clickhouse-connect` dependency:
+
+- clickhouse-connect
+
 Please note, most platforms have both psycopg2 and setuptools available as a separate, binary installed package.
 
 Installing psycopg2 and setuptools in Ubuntu:

--- a/docs/json_operations.md
+++ b/docs/json_operations.md
@@ -1,0 +1,321 @@
+# JSON Operations
+
+RickDb provides comprehensive support for working with JSON data in SQL queries through the `JsonField` and
+`PgJsonField` classes, as well as helper methods on the `Select` query builder.
+
+## Overview
+
+JSON support is available at two levels:
+
+- **JsonField** - Base class for JSON operations, works with any dialect that has `json_support` enabled
+- **PgJsonField** - PostgreSQL-specific extension with additional operations like `extract_object()`, `path_query()`,
+  and JSONB type casting
+- **Select helpers** - Convenience methods on the `Select` class: `json_field()`, `json_extract()`, and `json_where()`
+
+## JsonField
+
+The `JsonField` class wraps a JSON column name and provides methods that generate SQL expressions as `Literal` objects,
+suitable for use in `Select`, `where()`, and other query builder methods.
+
+```python
+from rick_db.sql import JsonField
+from rick_db.sql.dialect import PgSqlDialect
+
+pg = PgSqlDialect()
+json_field = JsonField('data', pg)
+```
+
+When no dialect is provided (or the dialect does not have `json_support`), fallback expressions using `JSON_EXTRACT()`
+and `JSON_CONTAINS()` are generated instead.
+
+### Extracting values
+
+```python
+from rick_db.sql import JsonField
+from rick_db.sql.dialect import PgSqlDialect
+
+pg = PgSqlDialect()
+jf = JsonField('data', pg)
+
+# Extract as text using ->> (PostgreSQL)
+expr = jf.extract('name')
+# output: "data"->>'name'
+print(expr)
+
+# Extract with alias
+expr = jf.extract('name', 'user_name')
+# output: "data"->>'name' AS "user_name"
+print(expr)
+
+# Extract as text (same as extract for PostgreSQL)
+expr = jf.extract_text('email', 'user_email')
+# output: "data"->>'email' AS "user_email"
+print(expr)
+```
+
+Without a dialect, generic `JSON_EXTRACT()` syntax is used:
+```python
+from rick_db.sql import JsonField
+
+jf = JsonField('data')
+
+expr = jf.extract('$.name')
+# output: JSON_EXTRACT(data, '$.name')
+print(expr)
+```
+
+### Checking containment and paths
+
+```python
+from rick_db.sql import JsonField
+from rick_db.sql.dialect import PgSqlDialect
+
+pg = PgSqlDialect()
+jf = JsonField('data', pg)
+
+# Check if JSON contains a value (generates parameterized SQL)
+expr = jf.contains('test')
+# output: "data" @> %s::jsonb
+print(expr)
+
+# Check if a path exists
+expr = jf.has_path('name')
+# output: "data" ?? 'name'
+print(expr)
+```
+
+### Bracket notation
+
+`JsonField` supports bracket notation for path access. Each bracket returns a new `JsonField`:
+
+```python
+from rick_db.sql import JsonField
+
+jf = JsonField('data')
+
+nested = jf['name']
+# output: data->>"name"
+print(nested)
+```
+
+For more details, see the [JsonField](classes/jsonfield.md) class reference.
+
+## PgJsonField
+
+`PgJsonField` extends `JsonField` with PostgreSQL-specific features for JSON and JSONB columns.
+
+```python
+from rick_db.sql import PgJsonField
+from rick_db.sql.dialect import PgSqlDialect
+
+pg = PgSqlDialect()
+jf = PgJsonField('data', pg)
+```
+
+### Extracting JSON objects
+
+The `extract_object()` method uses the `->` operator, which preserves the JSON type (unlike `->>` which returns text):
+
+```python
+from rick_db.sql import PgJsonField
+from rick_db.sql.dialect import PgSqlDialect
+
+pg = PgSqlDialect()
+jf = PgJsonField('data', pg)
+
+# Extract as JSON object (preserves type)
+expr = jf.extract_object('config')
+# output: "data"->'config'
+print(expr)
+
+# With alias
+expr = jf.extract_object('config', 'cfg')
+# output: "data"->'config' AS "cfg"
+print(expr)
+```
+
+### jsonpath queries (PostgreSQL 12+)
+
+```python
+from rick_db.sql import PgJsonField
+from rick_db.sql.dialect import PgSqlDialect
+
+pg = PgSqlDialect()
+jf = PgJsonField('data', pg)
+
+expr = jf.path_query('$.name')
+# output: "data"::jsonb @? '$.name'
+print(expr)
+```
+
+### Type casting
+
+```python
+from rick_db.sql import PgJsonField
+from rick_db.sql.dialect import PgSqlDialect
+
+pg = PgSqlDialect()
+jf = PgJsonField('data', pg)
+
+# Default is JSONB
+# output: data::jsonb
+print(jf)
+
+# Cast to JSON
+jf.as_json()
+# output: data::json
+print(jf)
+
+# Cast back to JSONB
+jf.as_jsonb()
+# output: data::jsonb
+print(jf)
+```
+
+### Bracket notation (PostgreSQL)
+
+`PgJsonField` brackets use the `->` operator (preserving JSON type), unlike `JsonField` which uses `->>`:
+
+```python
+from rick_db.sql import PgJsonField
+from rick_db.sql.dialect import PgSqlDialect
+
+pg = PgSqlDialect()
+jf = PgJsonField('data', pg)
+
+# Single level
+nested = jf['address']
+# output: data->"address"::jsonb
+print(nested)
+
+# Nested access
+nested = jf['address']['city']
+# output: data->"address"->"city"::jsonb
+print(nested)
+```
+
+For more details, see the [PgJsonField](classes/pgjsonfield.md) class reference.
+
+### Array index access
+
+PostgreSQL JSON operators also support numeric indices for arrays:
+
+```python
+from rick_db.sql import PgJsonField
+from rick_db.sql.dialect import PgSqlDialect
+
+pg = PgSqlDialect()
+jf = PgJsonField('tags', pg)
+
+# Extract first element as text
+expr = jf.extract(0)
+# output: "tags"->>0
+print(expr)
+```
+
+## Select helper methods
+
+The `Select` query builder provides convenience methods for JSON operations.
+
+### json_field()
+
+Creates a `JsonField` or `PgJsonField` instance bound to the current query's dialect:
+
+```python
+from rick_db.sql import Select
+from rick_db.sql.dialect import PgSqlDialect
+
+pg = PgSqlDialect()
+qry = Select(pg).from_('users')
+
+# Creates a PgJsonField (since dialect is PgSqlDialect)
+jf = qry.json_field('user_data')
+
+# With table qualifier
+jf = qry.json_field('config', 'users')
+```
+
+### json_extract()
+
+Adds a JSON extraction expression to the SELECT column list:
+
+```python
+from rick_db.sql import Select
+from rick_db.sql.dialect import PgSqlDialect
+
+pg = PgSqlDialect()
+qry = Select(pg).from_('users').json_extract('user_data', 'name', 'user_name')
+sql, _ = qry.assemble()
+# output: SELECT "users".*,"user_data"->>'name' AS "user_name" FROM "users"
+print(sql)
+```
+
+### json_where()
+
+Adds a WHERE condition on a JSON field:
+
+```python
+from rick_db.sql import Select
+from rick_db.sql.dialect import PgSqlDialect
+
+pg = PgSqlDialect()
+qry = Select(pg).from_('users').json_where('user_data', 'active', '=', True)
+sql, values = qry.assemble()
+# output: SELECT "users".* FROM "users" WHERE ("user_data"->>'active' = %s)
+print(sql)
+# values: [True]
+print(values)
+```
+
+## Complete example
+
+Combining JSON operations in a full query:
+
+```python
+from rick_db import fieldmapper
+from rick_db.sql import Select, PgJsonField
+from rick_db.sql.dialect import PgSqlDialect
+
+@fieldmapper(tablename='users', pk='id_user')
+class User:
+    id = 'id_user'
+    name = 'name'
+    profile = 'profile'  # JSONB column
+
+pg = PgSqlDialect()
+
+# Create a JSON field helper
+jf = PgJsonField(User.profile, pg)
+
+# Build a query that extracts JSON data and filters by JSON values
+qry = (
+    Select(pg)
+    .from_(User, [User.id, User.name])
+    .json_extract(User.profile, 'email', 'user_email')
+    .json_where(User.profile, 'active', '=', True)
+    .order(User.name)
+    .limit(10)
+)
+
+sql, values = qry.assemble()
+# output: SELECT "id_user","name","profile"->>'email' AS "user_email" FROM "users"
+#         WHERE ("profile"->>'active' = %s) ORDER BY "name" ASC LIMIT 10
+print(sql)
+# values: [True]
+print(values)
+```
+
+## Dialect support
+
+| Feature | PostgreSQL | SQLite | Generic |
+|---|---|---|---|
+| `extract()` | `->>` operator | Not built-in | `JSON_EXTRACT()` |
+| `extract_text()` | `->>` operator | Not built-in | `JSON_EXTRACT()` |
+| `extract_object()` | `->` operator | N/A | N/A |
+| `path_query()` | `@?` operator | N/A | N/A |
+| `contains()` | `@>` operator | Not built-in | `JSON_CONTAINS()` |
+| `has_path()` | `??` operator | Not built-in | `JSON_CONTAINS_PATH()` |
+| `as_jsonb()` / `as_json()` | Type casting | N/A | N/A |
+
+PostgreSQL has native JSON support enabled by default in `PgSqlDialect`. The `Sqlite3SqlDialect` does not currently
+enable `json_support`, so JSON operations will fall back to generic syntax if used with a `JsonField` without a dialect.

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -87,11 +87,11 @@ In addition to the parameters required by the connection object, there are two a
 
 |Parameter | Mandatory | Description|
 |---|---|---|
-|engine|yes|Database engine to use (currently "pgsql" or "sqlite")|
+|engine|yes|Database engine to use ("pgsql", "sqlite", or "clickhouse")|
 |passfile|no|Optional password file containing the database password|
 
 Engine is a mandatory field that specifies which database Connection object will be used. Currently, its value can
-be either 'pgsql' or 'sqlite'.
+be 'pgsql', 'sqlite', or 'clickhouse'.
 
 Passfile is an optional parameter indicating that the password should be read from an existing file
 instead. When **passfile** is used, the file is read into a **password** parameter automatically. Keep in

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
     - Manager: 'classes/managerinterface.md'
     - PgManager: 'classes/pgmanager.md'
     - Sqlite3Manager: 'classes/sqlite3manager.md'
+    - ClickHouseManager: 'classes/clickhousemanager.md'
 
 markdown_extensions:
 - toc:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,8 @@ nav:
   - DbGrid: 'classes/dbgrid.md'
   - QueryCache: 'classes/querycache.md'
   - Pool: 'classes/poolinterface.md'
+  - FieldRecord: 'classes/fieldrecord.md'
+  - UserRecord: 'classes/userrecord.md'
   - Manager:
     - Manager: 'classes/managerinterface.md'
     - PgManager: 'classes/pgmanager.md'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,7 @@ coverage==7.13.4
 tox==4.49.1
 tox-docker==5.0.0
 psycopg2-binary==2.9.11
+clickhouse-connect>=0.7.0
 setuptools>=75.6.0
 mkdocs
 mkdocs-material-extensions

--- a/rick_db/backend/clickhouse/__init__.py
+++ b/rick_db/backend/clickhouse/__init__.py
@@ -1,0 +1,5 @@
+from .connection import ClickHouseConnection
+from .manager import ClickHouseManager
+from .migrations import ClickHouseMigrationManager
+from .repository import ClickHouseRepository
+from .sql import ClickHouseUpdate, ClickHouseDelete

--- a/rick_db/backend/clickhouse/connection.py
+++ b/rick_db/backend/clickhouse/connection.py
@@ -1,0 +1,99 @@
+from rick_db import Connection
+from rick_db.sql import ClickHouseSqlDialect
+
+
+class ClickHouseCursorWrapper:
+    """
+    DB-API 2.0 cursor wrapper for clickhouse-connect Client.
+
+    The clickhouse-connect Client doesn't follow the DB-API 2.0 spec,
+    so this wrapper provides the interface that rick_db's Cursor class expects.
+    """
+
+    # Query prefixes that return result sets
+    _SELECT_PREFIXES = ("SELECT", "SHOW", "DESCRI", "WITH", "EXPLAI")
+
+    def __init__(self, client):
+        self._client = client
+        self._rows = []
+        self._description = None
+        self.lastrowid = None
+
+    def execute(self, query, params=None):
+        if params is not None:
+            params = tuple(params) if isinstance(params, list) else params
+
+        query_type = query.lstrip()[:6].upper()
+        if query_type.startswith(self._SELECT_PREFIXES):
+            result = self._client.query(query, parameters=params or None)
+            self._description = [(name,) for name in result.column_names]
+            self._rows = [
+                dict(zip(result.column_names, row))
+                for row in result.result_rows
+            ]
+        else:
+            self._client.command(query, parameters=params or None)
+            self._description = None
+            self._rows = []
+
+    @property
+    def description(self):
+        return self._description
+
+    def fetchall(self):
+        return self._rows
+
+    def fetchone(self):
+        return self._rows[0] if self._rows else None
+
+    def close(self):
+        self._rows = []
+        self._description = None
+
+
+class ClickHouseClientWrapper:
+    """
+    DB-API 2.0 connection wrapper for clickhouse-connect Client.
+
+    Provides cursor(), commit(), rollback(), close() methods that
+    rick_db's Connection base class expects.
+    """
+
+    def __init__(self, client):
+        self._client = client
+        self.autocommit = False
+
+    def cursor(self):
+        return ClickHouseCursorWrapper(self._client)
+
+    def commit(self):
+        pass  # no-op: ClickHouse has no transactions
+
+    def rollback(self):
+        pass  # no-op
+
+    def close(self):
+        self._client.close()
+
+
+class ClickHouseConnection(Connection):
+    """
+    ClickHouse connection using clickhouse-connect HTTP client.
+
+    ClickHouse has no real transactions - each statement is its own unit of work.
+    commit() and rollback() are no-ops. The transaction() context manager on
+    Repository will work without errors but provides no atomicity guarantees.
+    """
+
+    def __init__(self, **kwargs):
+        import clickhouse_connect
+
+        client = clickhouse_connect.get_client(**kwargs)
+        wrapper = ClickHouseClientWrapper(client)
+        self.autocommit = False
+        super().__init__(None, wrapper, ClickHouseSqlDialect())
+
+    @property
+    def client(self):
+        """Access the underlying clickhouse-connect Client"""
+        return self.db._client

--- a/rick_db/backend/clickhouse/manager.py
+++ b/rick_db/backend/clickhouse/manager.py
@@ -1,0 +1,191 @@
+from contextlib import contextmanager
+from typing import Optional, List
+
+from rick_db import Connection
+from rick_db.manager import ManagerInterface, FieldRecord, UserRecord
+
+
+class ClickHouseManager(ManagerInterface):
+    """
+    ClickHouse database manager for introspection operations.
+
+    Uses ClickHouse system.* tables for metadata queries.
+    The schema parameter maps to ClickHouse database; when None,
+    uses the connection's current database.
+    """
+
+    def __init__(self, db):
+        self._db = db
+        self.dialect = db.dialect()
+        # extract current database from client config
+        self._database = db.client.database
+
+    @contextmanager
+    def conn(self) -> Connection:
+        yield self._db
+
+    def backend(self):
+        return self._db
+
+    def tables(self, schema=None) -> List[str]:
+        database = schema or self._database
+        sql = (
+            "SELECT name FROM system.tables "
+            "WHERE database = %s "
+            "AND engine NOT IN ('View', 'MaterializedView') "
+            "ORDER BY name"
+        )
+        with self.conn() as conn:
+            with conn.cursor() as c:
+                rows = c.fetchall(sql, [database])
+                return [r["name"] for r in rows]
+
+    def views(self, schema=None) -> List[str]:
+        database = schema or self._database
+        sql = (
+            "SELECT name FROM system.tables "
+            "WHERE database = %s "
+            "AND engine IN ('View', 'MaterializedView') "
+            "ORDER BY name"
+        )
+        with self.conn() as conn:
+            with conn.cursor() as c:
+                rows = c.fetchall(sql, [database])
+                return [r["name"] for r in rows]
+
+    def schemas(self) -> List[str]:
+        return self.databases()
+
+    def databases(self) -> List[str]:
+        sql = "SELECT name FROM system.databases ORDER BY name"
+        with self.conn() as conn:
+            with conn.cursor() as c:
+                rows = c.fetchall(sql)
+                return [r["name"] for r in rows]
+
+    def table_indexes(self, table_name: str, schema=None) -> List[FieldRecord]:
+        database = schema or self._database
+        sql = (
+            "SELECT name AS field, type_full AS type, 0 AS \"primary\" "
+            "FROM system.data_skipping_indices "
+            "WHERE database = %s AND table = %s "
+            "ORDER BY name"
+        )
+        with self.conn() as conn:
+            with conn.cursor() as c:
+                return c.fetchall(sql, [database, table_name], cls=FieldRecord)
+
+    def table_pk(self, table_name: str, schema=None) -> Optional[FieldRecord]:
+        database = schema or self._database
+        sql = (
+            "SELECT name AS field, type, 1 AS \"primary\" "
+            "FROM system.columns "
+            "WHERE database = %s AND table = %s AND is_in_primary_key = 1 "
+            "ORDER BY position"
+        )
+        with self.conn() as conn:
+            with conn.cursor() as c:
+                result = c.fetchone(sql, [database, table_name], cls=FieldRecord)
+                return result
+
+    def table_fields(self, table_name: str, schema=None) -> List[FieldRecord]:
+        database = schema or self._database
+        sql = (
+            "SELECT name AS field, type, is_in_primary_key AS \"primary\" "
+            "FROM system.columns "
+            "WHERE database = %s AND table = %s "
+            "ORDER BY position"
+        )
+        with self.conn() as conn:
+            with conn.cursor() as c:
+                result = c.fetchall(sql, [database, table_name], cls=FieldRecord)
+                for r in result:
+                    r.primary = r.primary == 1
+                return result
+
+    def view_fields(self, view_name: str, schema=None) -> List[FieldRecord]:
+        return self.table_fields(view_name, schema)
+
+    def users(self) -> List[UserRecord]:
+        sql = "SELECT name FROM system.users ORDER BY name"
+        with self.conn() as conn:
+            with conn.cursor() as c:
+                rows = c.fetchall(sql)
+                return [UserRecord(name=r["name"]) for r in rows]
+
+    def user_groups(self, user_name: str) -> List[str]:
+        return []
+
+    def table_exists(self, table_name: str, schema=None) -> bool:
+        database = schema or self._database
+        sql = (
+            "SELECT count() AS cnt FROM system.tables "
+            "WHERE database = %s AND name = %s"
+        )
+        with self.conn() as conn:
+            with conn.cursor() as c:
+                result = c.fetchone(sql, [database, table_name])
+                return result is not None and result["cnt"] > 0
+
+    def view_exists(self, view_name: str, schema=None) -> bool:
+        database = schema or self._database
+        sql = (
+            "SELECT count() AS cnt FROM system.tables "
+            "WHERE database = %s AND name = %s "
+            "AND engine IN ('View', 'MaterializedView')"
+        )
+        with self.conn() as conn:
+            with conn.cursor() as c:
+                result = c.fetchone(sql, [database, view_name])
+                return result is not None and result["cnt"] > 0
+
+    def create_database(self, database_name: str, **kwargs):
+        sql = "CREATE DATABASE IF NOT EXISTS {}".format(
+            self.dialect.database(database_name)
+        )
+        with self.conn() as conn:
+            with conn.cursor() as c:
+                c.exec(sql)
+
+    def database_exists(self, database_name: str) -> bool:
+        sql = "SELECT count() AS cnt FROM system.databases WHERE name = %s"
+        with self.conn() as conn:
+            with conn.cursor() as c:
+                result = c.fetchone(sql, [database_name])
+                return result is not None and result["cnt"] > 0
+
+    def drop_database(self, database_name: str):
+        sql = "DROP DATABASE IF EXISTS {}".format(
+            self.dialect.database(database_name)
+        )
+        with self.conn() as conn:
+            with conn.cursor() as c:
+                c.exec(sql)
+
+    def create_schema(self, schema: str, **kwargs):
+        raise NotImplementedError("ClickHouse: schemas are databases, use create_database()")
+
+    def schema_exists(self, schema: str) -> bool:
+        return self.database_exists(schema)
+
+    def drop_schema(self, schema: str, cascade: bool = False):
+        raise NotImplementedError("ClickHouse: schemas are databases, use drop_database()")
+
+    def kill_clients(self, database_name: str):
+        raise NotImplementedError("ClickHouse: feature not supported")
+
+    def drop_table(self, table_name: str, cascade: bool = False, schema: str = None):
+        sql = "DROP TABLE IF EXISTS {}".format(
+            self.dialect.table(table_name, schema=schema)
+        )
+        with self.conn() as conn:
+            with conn.cursor() as c:
+                c.exec(sql)
+
+    def drop_view(self, view_name: str, cascade: bool = False, schema: str = None):
+        sql = "DROP VIEW IF EXISTS {}".format(
+            self.dialect.table(view_name, schema=schema)
+        )
+        with self.conn() as conn:
+            with conn.cursor() as c:
+                c.exec(sql)

--- a/rick_db/backend/clickhouse/migrations.py
+++ b/rick_db/backend/clickhouse/migrations.py
@@ -1,0 +1,57 @@
+from datetime import datetime
+
+from rick_db.migrations import BaseMigrationManager, MigrationRecord, MigrationResult
+from rick_db.mapper import ATTR_TABLE
+from rick_db.sql import ClickHouseSqlDialect
+
+
+class ClickHouseMigrationManager(BaseMigrationManager):
+
+    def _migration_table_sql(self, table_name: str) -> str:
+        """
+        SQL for migration table creation using ClickHouse MergeTree engine.
+        Uses UUID for id_migration and DateTime for applied timestamp.
+        """
+        return """
+        CREATE TABLE IF NOT EXISTS {name} (
+            id_migration UUID DEFAULT generateUUIDv4(),
+            applied DateTime DEFAULT now(),
+            name String
+        ) ENGINE = MergeTree()
+        ORDER BY (name)
+        """.format(name=ClickHouseSqlDialect().table(table_name))
+
+    def flatten(self, record: MigrationRecord) -> MigrationResult:
+        """
+        Remove all records from the migration table, and replace with a new record.
+        Uses TRUNCATE TABLE instead of DELETE WHERE (cleaner for ClickHouse,
+        avoids UUID comparison issues).
+        """
+        try:
+            setattr(record, ATTR_TABLE, self.MIGRATION_TABLE)
+            record.applied = datetime.now().isoformat()
+
+            sql = "TRUNCATE TABLE {}".format(
+                ClickHouseSqlDialect().table(self.MIGRATION_TABLE)
+            )
+            with self.manager.conn() as conn:
+                with conn.cursor() as c:
+                    c.exec(sql)
+
+            self.repository.insert(record)
+            return MigrationResult(success=True, error="")
+        except Exception as e:
+            return MigrationResult(success=False, error=str(e))
+
+    def _exec(self, content):
+        """
+        Execute migration using a cursor.
+        Splits multi-statement SQL on ';' since clickhouse-connect's
+        command() only accepts one statement at a time.
+        """
+        with self.manager.conn() as conn:
+            with conn.cursor() as c:
+                for statement in content.split(";"):
+                    statement = statement.strip()
+                    if statement:
+                        c.exec(statement)

--- a/rick_db/backend/clickhouse/repository.py
+++ b/rick_db/backend/clickhouse/repository.py
@@ -1,0 +1,139 @@
+from typing import Any, Optional
+
+from rick_db.repository import Repository, RepositoryError
+from rick_db.mapper import ATTR_PRIMARY_KEY
+from rick_db.sql import Insert
+from .sql import ClickHouseUpdate, ClickHouseDelete
+
+
+class ClickHouseRepository(Repository):
+    """
+    ClickHouse-specific Repository.
+
+    Overrides update/delete operations to use ALTER TABLE mutations,
+    and insert_pk to return None (ClickHouse has no RETURNING or lastrowid).
+    """
+
+    def insert_pk(self, record) -> Any:
+        """
+        Insert a record. Returns None since ClickHouse has no RETURNING
+        or auto-increment primary keys.
+
+        :param record: record object to insert
+        :return: None
+        """
+        pk = self.pk
+        if pk is None:
+            pk = getattr(record, ATTR_PRIMARY_KEY, None)
+
+        if pk is None:
+            raise RepositoryError("insert_pk(): record has no primary key")
+
+        sql, values = Insert(self.dialect).into(record).assemble()
+        with self.cursor() as c:
+            c.exec(sql, values)
+        return None
+
+    def delete_pk(self, pk_value):
+        """
+        Delete a record by primary key using ALTER TABLE ... DELETE WHERE.
+
+        :param pk_value: primary key value
+        :return: None
+        """
+        if self.pk is None:
+            raise RepositoryError("delete_pk(): record has no primary key")
+
+        sql = self.query_cache.get("delete_pk")
+        if sql is None:
+            sql, values = (
+                ClickHouseDelete(self.dialect)
+                .from_(self._record)
+                .where(self.pk, "=", pk_value)
+                .assemble()
+            )
+            self.query_cache.set("delete_pk", sql)
+        else:
+            values = [pk_value]
+        with self.cursor() as c:
+            c.exec(sql, values)
+
+    def delete_where(self, where_clauses: list):
+        """
+        Delete rows matching WHERE clauses using ALTER TABLE ... DELETE WHERE.
+
+        :param where_clauses: list of (field, operator, value) tuples
+        """
+        qry = ClickHouseDelete(self.dialect).from_(self._record)
+
+        if len(where_clauses) == 0:
+            raise RepositoryError("delete_where(): where_clauses is empty")
+
+        for clause in where_clauses:
+            if len(clause) != 3:
+                raise RepositoryError("delete_where(): invalid length for where clause")
+            qry.where(clause[0], clause[1], clause[2])
+
+        qry, values = qry.assemble()
+        with self.cursor() as c:
+            c.exec(qry, values)
+
+    def update(self, record, pk_value=None):
+        """
+        Update a record using ALTER TABLE ... UPDATE ... WHERE.
+
+        :param record: record object
+        :param pk_value: optional primary key value
+        """
+        if self.pk is None:
+            raise RepositoryError("update(): missing primary key")
+        data = record.asrecord()
+
+        value = pk_value
+        if self.pk in data.keys():
+            value = data[self.pk]
+            del data[self.pk]
+
+        if value is None:
+            raise RepositoryError("update(): missing primary key value")
+        sql, values = (
+            ClickHouseUpdate(self.dialect)
+            .table(self.table_name, self.schema)
+            .values(data)
+            .where(self.pk, "=", value)
+            .assemble()
+        )
+        with self.cursor() as c:
+            c.exec(sql, values)
+
+    def update_where(self, record, where_list: list):
+        """
+        Update a record with custom WHERE conditions using ALTER TABLE ... UPDATE.
+
+        :param record: record to update
+        :param where_list: list of where conditions
+        """
+        if type(where_list) not in [list, tuple]:
+            raise RepositoryError("update_where(): invalid type for where clause list")
+        if len(where_list) == 0:
+            raise RepositoryError("update_where(): where clause list cannot be empty")
+
+        qry = ClickHouseUpdate(self.dialect).table(self.table_name, self.schema).values(record)
+        for cond in where_list:
+            if type(cond) not in [list, tuple]:
+                raise RepositoryError(
+                    "update_where(): invalid item in where clause list"
+                )
+            lc = len(cond)
+            if lc == 2:
+                qry.where(cond[0], operator="=", value=cond[1])
+            elif lc == 3:
+                qry.where(cond[0], operator=cond[1], value=cond[2])
+            else:
+                raise RepositoryError(
+                    "update_where(): invalid item in where clause list"
+                )
+
+        sql, values = qry.assemble()
+        with self.cursor() as c:
+            c.exec(sql, values)

--- a/rick_db/backend/clickhouse/sql.py
+++ b/rick_db/backend/clickhouse/sql.py
@@ -1,0 +1,107 @@
+from rick_db.mapper import ATTR_TABLE, ATTR_SCHEMA
+from rick_db.sql import (
+    SqlStatement,
+    SqlDialect,
+    SqlError,
+    Sql,
+    Literal,
+    DefaultSqlDialect,
+    Select,
+    ClickHouseSqlDialect,
+)
+from rick_db.sql.update import Update
+from rick_db.sql.delete import Delete
+
+
+class ClickHouseUpdate(Update):
+    """
+    ClickHouse UPDATE builder.
+
+    Generates ALTER TABLE ... UPDATE syntax instead of standard UPDATE ... SET.
+    ClickHouse does not support standard SQL UPDATE; mutations must use
+    ALTER TABLE ... UPDATE ... WHERE ...
+    """
+
+    def assemble(self):
+        """
+        Assemble the ALTER TABLE ... UPDATE statement
+        :return: tuple(str, list)
+        """
+        lf = len(self._fields)
+        if lf == 0:
+            raise SqlError("assemble(): field list is empty")
+        if lf != len(self._values):
+            raise SqlError("assemble(): field and value count mismatch")
+
+        parts = [
+            "ALTER TABLE",
+            self._dialect.table(self._table, None, schema=self._schema),
+            Sql.SQL_UPDATE,
+        ]
+
+        # generate field=value assignments
+        fields = []
+        values = []
+        expression = "{}={}"
+        for i in range(0, lf):
+            name = self._dialect.field(self._fields[i])
+            value = self._values[i]
+            if isinstance(value, Literal):
+                fields.append(expression.format(name, str(value)))
+            elif isinstance(value, Select):
+                value, sql_values = value.assemble()
+                values.extend(sql_values)
+                fields.append(expression.format(name, value))
+            else:
+                fields.append(expression.format(name, self._dialect.placeholder))
+                values.append(value)
+
+        parts.append(", ".join(fields))
+
+        # where clause
+        if len(self._clauses) > 0:
+            c = 0
+            parts.append(Sql.SQL_WHERE)
+            values.extend(self._clause_values)
+
+            for clause in self._clauses:
+                expr, concat = clause
+                if c > 0:
+                    parts.append(concat)
+                parts.append(expr)
+                c += 1
+
+        return " ".join(parts), values
+
+
+class ClickHouseDelete(Delete):
+    """
+    ClickHouse DELETE builder.
+
+    Generates ALTER TABLE ... DELETE WHERE syntax instead of standard
+    DELETE FROM ... WHERE. ClickHouse does not support standard SQL DELETE;
+    mutations must use ALTER TABLE ... DELETE WHERE ...
+    """
+
+    def assemble(self):
+        """
+        Assemble the ALTER TABLE ... DELETE statement
+        :return: tuple(str, list)
+        """
+        parts = [
+            "ALTER TABLE",
+            self._dialect.table(self._table, None, self._schema),
+            "DELETE",
+        ]
+
+        if len(self._clauses) > 0:
+            c = 0
+            parts.append(Sql.SQL_WHERE)
+            for clause in self._clauses:
+                expr, concat = clause
+                if c > 0:
+                    parts.append(concat)
+                parts.append(expr)
+                c += 1
+
+        return " ".join(parts), self._values

--- a/rick_db/cli/manage.py
+++ b/rick_db/cli/manage.py
@@ -17,6 +17,7 @@ class CliManager:
     DB_FACTORIES = {
         "_pgsql": ["pg", "pgsql", "postgres"],
         "_sqlite": ["sqlite", "sql3", "sqlite3"],
+        "_clickhouse": ["clickhouse", "ch"],
     }
 
     def __init__(self, prog_name: str, tty: ConsoleWriter, cfg: dict):
@@ -146,6 +147,26 @@ class CliManager:
             conn = Sqlite3Connection(**cfg)
             mgr = Sqlite3Manager(conn)
             return Sqlite3MigrationManager(mgr)
+        except Exception as e:
+            self._tty.error("Error: {}".format(str(e)))
+            return None
+
+    def _clickhouse(self, cfg: dict) -> Optional[BaseMigrationManager]:
+        """
+        Assemble ClickHouse Migration Manager instance
+        :param cfg: Conn parameters
+        :return: MigrationManager instance
+        """
+        from rick_db.backend.clickhouse import (
+            ClickHouseConnection,
+            ClickHouseManager,
+        )
+        from rick_db.backend.clickhouse.migrations import ClickHouseMigrationManager
+
+        try:
+            conn = ClickHouseConnection(**cfg)
+            mgr = ClickHouseManager(conn)
+            return ClickHouseMigrationManager(mgr)
         except Exception as e:
             self._tty.error("Error: {}".format(str(e)))
             return None

--- a/rick_db/mapper.py
+++ b/rick_db/mapper.py
@@ -7,6 +7,7 @@ ATTR_FIELDS = "_fieldmap"
 ATTR_TABLE = "_tablename"
 ATTR_SCHEMA = "_schema"
 ATTR_PRIMARY_KEY = "_pk"
+ATTR_JSON_EXCLUDE = "_json_exclude"
 ATTR_ROW = "_row"
 
 
@@ -27,7 +28,7 @@ class Record:
     def pk(self):
         pass
 
-    def asdict(self):
+    def asdict(self, exclude=None):
         pass
 
     def asrecord(self):
@@ -51,6 +52,7 @@ class BaseRecord(Record):
     _tablename = None
     _schema = None
     _pk = None
+    _json_exclude = set()
 
     def __init__(self, **kwargs):
         self._row = {}  # row must be a local scoped var
@@ -116,11 +118,15 @@ class BaseRecord(Record):
             return row[pk]
         raise AttributeError("primary key value is not set")
 
-    def asdict(self):
+    def asdict(self, exclude=None):
+        if exclude is None:
+            skip = self._json_exclude
+        else:
+            skip = set(exclude) | self._json_exclude
         result = {}
         data = self._row
         for key, dbfield in self._fieldmap.items():
-            if dbfield in data.keys():
+            if key not in skip and dbfield in data.keys():
                 result[key] = data[dbfield]
         return result
 
@@ -204,7 +210,7 @@ def _base_record_method_map() -> dict:
     return methods
 
 
-def fieldmapper(cls=None, pk=None, tablename=None, schema=None, clsonly=False):
+def fieldmapper(cls=None, pk=None, tablename=None, schema=None, clsonly=False, json_exclude=None):
     def wrap(cls):
         fieldmap = {}
         if clsonly:
@@ -228,6 +234,7 @@ def fieldmapper(cls=None, pk=None, tablename=None, schema=None, clsonly=False):
         setattr(cls, ATTR_TABLE, tablename)
         setattr(cls, ATTR_SCHEMA, schema)
         setattr(cls, ATTR_PRIMARY_KEY, pk)
+        setattr(cls, ATTR_JSON_EXCLUDE, set(json_exclude) if json_exclude else set())
         # row attr is set, but will be shadowed by internal attribute on __init__
         setattr(cls, ATTR_ROW, {})
 

--- a/rick_db/sql/__init__.py
+++ b/rick_db/sql/__init__.py
@@ -1,5 +1,5 @@
 from .common import SqlError, SqlStatement, Sql, Literal, L, JsonField, PgJsonField
-from .dialect import SqlDialect, Sqlite3SqlDialect, PgSqlDialect, DefaultSqlDialect
+from .dialect import SqlDialect, Sqlite3SqlDialect, PgSqlDialect, DefaultSqlDialect, ClickHouseSqlDialect
 from .select import Select
 from .insert import Insert
 from .delete import Delete
@@ -18,6 +18,7 @@ __all__ = [
     "Sqlite3SqlDialect",
     "PgSqlDialect",
     "DefaultSqlDialect",
+    "ClickHouseSqlDialect",
     "Select",
     "Insert",
     "Delete",

--- a/rick_db/sql/dialect.py
+++ b/rick_db/sql/dialect.py
@@ -34,6 +34,17 @@ class SqlDialect:
             "JSON_CONTAINS_PATH({field}, 'one', {path})"  # Check if path exists
         )
 
+    def _qi(self, identifier):
+        """
+        Quote a SQL identifier, escaping embedded double-quotes by doubling them
+        (SQL standard).
+
+        :param identifier: identifier name (table, field, schema, database)
+        :return: quoted identifier string, e.g. '"my_table"'
+        """
+        escaped = identifier.replace('"', '""')
+        return '"{}"'.format(escaped)
+
     def table(self, table_name, alias=None, schema=None):
         """
         Quotes a table name
@@ -48,11 +59,11 @@ class SqlDialect:
         """
         if not isinstance(table_name, Literal):
             # table is a string to be quoted and schema-prefixed
-            table_name = self._quote_table.format(table=table_name)
+            table_name = self._qi(table_name)
 
             if schema is not None:
                 table_name = (
-                    self._quote_schema.format(schema=schema)
+                    self._qi(schema)
                     + self._separator
                     + table_name
                 )
@@ -62,7 +73,7 @@ class SqlDialect:
 
         if alias is None:
             return table_name
-        return self._as.join([table_name, self._quote_table.format(table=alias)])
+        return self._as.join([table_name, self._qi(alias)])
 
     def field(self, field, field_alias=None, table=None, schema=None):
         """
@@ -83,10 +94,10 @@ class SqlDialect:
             field('field', 'alias', 'table', 'public') -> "public"."table"."field" AS "alias"
         """
         if table is not None:
-            table = self._quote_table.format(table=table) + self._separator
+            table = self._qi(table) + self._separator
             if schema is not None:
                 table = (
-                    self._quote_schema.format(schema=schema) + self._separator + table
+                    self._qi(schema) + self._separator + table
                 )
         else:
             table = ""
@@ -95,13 +106,13 @@ class SqlDialect:
             field = str(field)
             table = ""
         elif field != "*":
-            field = self._quote_field.format(field=field)
+            field = self._qi(field)
         field = table + field
 
         if field_alias is None:
             return field
         elif isinstance(field_alias, str):
-            return self._as.join([field, self._quote_field.format(field=field_alias)])
+            return self._as.join([field, self._qi(field_alias)])
         elif isinstance(field_alias, (list, tuple)):
             _len = len(field_alias)
             if _len == 0:
@@ -109,7 +120,7 @@ class SqlDialect:
             field = self._cast.format(field=field, cast=field_alias[0])
             if _len > 1:
                 return self._as.join(
-                    [field, self._quote_field.format(field=field_alias[1])]
+                    [field, self._qi(field_alias[1])]
                 )
             else:
                 return field
@@ -128,8 +139,8 @@ class SqlDialect:
             table('name', 'alias') -> "name" AS "alias"
         """
         if not isinstance(database_name, Literal):
-            # database_name is a string to be
-            database_name = self._quote_database.format(database=database_name)
+            # database_name is a string to be quoted
+            database_name = self._qi(database_name)
         else:
             # database_name is actually a Literal expression, just add parenthesis
             database_name = "({database})".format(database=database_name)
@@ -137,7 +148,7 @@ class SqlDialect:
         if alias is None:
             return database_name
         return self._as.join(
-            [database_name, self._quote_database.format(database=alias)]
+            [database_name, self._qi(alias)]
         )
 
     def _json_field_expr(self, field):
@@ -155,7 +166,7 @@ class SqlDialect:
                 parts = field.split(".", 1)
                 return self.field(parts[1], table=parts[0])
             else:
-                return self._quote_field.format(field=field)
+                return self._qi(field)
         else:
             return str(field)
 
@@ -188,7 +199,7 @@ class SqlDialect:
         expr = self._json_extract.format(field=field_expr, path=path)
 
         if alias:
-            return self._as.join([expr, self._quote_field.format(field=alias)])
+            return self._as.join([expr, self._qi(alias)])
         return expr
 
     def json_extract_text(self, field, path, alias=None):
@@ -220,7 +231,7 @@ class SqlDialect:
         expr = self._json_extract_text.format(field=field_expr, path=path)
 
         if alias:
-            return self._as.join([expr, self._quote_field.format(field=alias)])
+            return self._as.join([expr, self._qi(alias)])
         return expr
 
     def json_contains(self, field, value, alias=None):
@@ -245,7 +256,7 @@ class SqlDialect:
         expr = self._json_contains.format(field=field_expr, value=self.placeholder)
 
         if alias:
-            return self._as.join([expr, self._quote_field.format(field=alias)])
+            return self._as.join([expr, self._qi(alias)])
         return expr
 
     def json_contains_path(self, field, path, alias=None):
@@ -277,7 +288,7 @@ class SqlDialect:
         expr = self._json_contains_path.format(field=field_expr, path=path)
 
         if alias:
-            return self._as.join([expr, self._quote_field.format(field=alias)])
+            return self._as.join([expr, self._qi(alias)])
         return expr
 
 
@@ -338,10 +349,10 @@ class PgSqlDialect(SqlDialect):
             field('field', 'alias', 'table', 'public') -> "public"."table"."field" AS "alias"
         """
         if table is not None:
-            table = self._quote_table.format(table=table) + self._separator
+            table = self._qi(table) + self._separator
             if schema is not None:
                 table = (
-                    self._quote_schema.format(schema=schema) + self._separator + table
+                    self._qi(schema) + self._separator + table
                 )
         else:
             table = ""
@@ -350,13 +361,13 @@ class PgSqlDialect(SqlDialect):
             field = str(field)
             table = ""
         elif field != "*":
-            field = self._quote_field.format(field=field)
+            field = self._qi(field)
         field = table + field
 
         if field_alias is None:
             return field
         elif isinstance(field_alias, str):
-            return self._as.join([field, self._quote_field.format(field=field_alias)])
+            return self._as.join([field, self._qi(field_alias)])
         elif isinstance(field_alias, (list, tuple)):
             _len = len(field_alias)
             if _len == 0:
@@ -365,7 +376,7 @@ class PgSqlDialect(SqlDialect):
             cast = self._cast + field_alias[0]
             if _len > 1:
                 return self._as.join(
-                    [field + cast, self._quote_field.format(field=field_alias[1])]
+                    [field + cast, self._qi(field_alias[1])]
                 )
             else:
                 return field + cast
@@ -412,7 +423,7 @@ class PgSqlDialect(SqlDialect):
         expr = self._json_extract.format(field=field_expr, path=path_expr)
 
         if alias:
-            return self._as.join([expr, self._quote_field.format(field=alias)])
+            return self._as.join([expr, self._qi(alias)])
         return expr
 
     def json_extract_text(self, field, path, alias=None):
@@ -437,7 +448,7 @@ class PgSqlDialect(SqlDialect):
         expr = self._json_extract_text.format(field=field_expr, path=path_expr)
 
         if alias:
-            return self._as.join([expr, self._quote_field.format(field=alias)])
+            return self._as.join([expr, self._qi(alias)])
         return expr
 
     def json_extract_object(self, field, path, alias=None):
@@ -460,7 +471,7 @@ class PgSqlDialect(SqlDialect):
         expr = self._json_extract_object.format(field=field_expr, path=path_expr)
 
         if alias:
-            return self._as.join([expr, self._quote_field.format(field=alias)])
+            return self._as.join([expr, self._qi(alias)])
         return expr
 
     def json_path_query(self, field, path, alias=None):
@@ -484,7 +495,85 @@ class PgSqlDialect(SqlDialect):
         expr = "{}::jsonb @? {}".format(field_expr, path)
 
         if alias:
-            return self._as.join([expr, self._quote_field.format(field=alias)])
+            return self._as.join([expr, self._qi(alias)])
+        return expr
+
+
+class ClickHouseSqlDialect(SqlDialect):
+    """
+    ClickHouse SqlDialect implementation
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.placeholder = "%s"
+        self.insert_returning = False  # ClickHouse has no RETURNING
+        self.ilike = True  # ClickHouse supports ILIKE
+        self.json_support = True  # ClickHouse has JSON functions
+
+        self._cast = "CAST({field} AS {cast})"
+
+        # ClickHouse JSON operators use function syntax
+        self._json_extract = "JSONExtractString({field}, {path})"
+        self._json_extract_text = "JSONExtractString({field}, {path})"
+        self._json_contains = "JSONHas({field}, {value})"
+        self._json_contains_path = "JSON_EXISTS({field}, {path})"
+
+    def _ch_path_expr(self, path):
+        """
+        Convert a path argument to ClickHouse JSON function format.
+        Strips jsonpath prefix (e.g. $.name -> name).
+
+        :param path: key name or jsonpath expression
+        :return: formatted path expression
+        """
+        if isinstance(path, str):
+            if path.startswith("$."):
+                path = path[2:]
+            path = path.strip("'\"")
+            return "'{}'".format(path)
+        return str(path)
+
+    def json_extract(self, field, path, alias=None):
+        """
+        Extract a value from a JSON field using JSONExtractString.
+
+        :param field: JSON field name, table-qualified string, or Literal expression
+        :param path: key name (jsonpath $. prefix is stripped automatically)
+        :param alias: optional alias for the result
+        :return: SQL expression string
+        """
+        if not self.json_support:
+            raise SqlError("JSON operations not supported in this SQL dialect")
+
+        field_expr = self._json_field_expr(field)
+        path_expr = self._ch_path_expr(path)
+
+        expr = self._json_extract.format(field=field_expr, path=path_expr)
+
+        if alias:
+            return self._as.join([expr, self._qi(alias)])
+        return expr
+
+    def json_extract_text(self, field, path, alias=None):
+        """
+        Extract a value from a JSON field as text using JSONExtractString.
+
+        :param field: JSON field name, table-qualified string, or Literal expression
+        :param path: key name (jsonpath $. prefix is stripped automatically)
+        :param alias: optional alias for the result
+        :return: SQL expression string
+        """
+        if not self.json_support:
+            raise SqlError("JSON operations not supported in this SQL dialect")
+
+        field_expr = self._json_field_expr(field)
+        path_expr = self._ch_path_expr(path)
+
+        expr = self._json_extract_text.format(field=field_expr, path=path_expr)
+
+        if alias:
+            return self._as.join([expr, self._qi(alias)])
         return expr
 
 

--- a/tests/backend/clickhouse/conftest.py
+++ b/tests/backend/clickhouse/conftest.py
@@ -1,0 +1,33 @@
+import pytest
+
+from rick_db.backend.clickhouse import ClickHouseConnection, ClickHouseManager
+
+
+def _clickhouse_available(settings):
+    """Check if a ClickHouse server is reachable."""
+    try:
+        conn = ClickHouseConnection(**settings)
+        with conn.cursor() as c:
+            c.exec("SELECT 1")
+        conn.close()
+        return True
+    except Exception:
+        return False
+
+
+@pytest.fixture
+def ch_backend(ch_settings):
+    if not _clickhouse_available(ch_settings):
+        pytest.skip("ClickHouse server not available")
+
+    conn = ClickHouseConnection(**ch_settings)
+    yield conn
+
+    # teardown
+    mgr = ClickHouseManager(conn)
+    mgr.drop_table("_migration")
+    mgr.drop_view("list_animal")
+    mgr.drop_table("animal")
+    mgr.drop_table("users")
+
+    conn.close()

--- a/tests/backend/clickhouse/test_clickhouse_connection.py
+++ b/tests/backend/clickhouse/test_clickhouse_connection.py
@@ -1,0 +1,72 @@
+import pytest
+
+from rick_db.backend.clickhouse import ClickHouseConnection
+from rick_db.sql import ClickHouseSqlDialect
+
+
+@pytest.fixture
+def conn(ch_settings):
+    try:
+        c = ClickHouseConnection(**ch_settings)
+    except Exception:
+        pytest.skip("ClickHouse server not available")
+        return
+
+    yield c
+    c.close()
+
+
+class TestClickHouseConnectionIntegration:
+    def test_connect(self, conn):
+        assert conn is not None
+        assert isinstance(conn.dialect(), ClickHouseSqlDialect)
+
+    def test_client_property(self, conn):
+        assert conn.client is not None
+
+    def test_autocommit(self, conn):
+        assert conn.autocommit is False
+
+    def test_dialect(self, conn):
+        d = conn.dialect()
+        assert d.placeholder == "%s"
+        assert d.insert_returning is False
+        assert d.ilike is True
+
+    def test_cursor_select(self, conn):
+        with conn.cursor() as c:
+            result = c.exec("SELECT 1 AS val")
+            assert len(result) == 1
+            assert result[0]["val"] == 1
+
+    def test_cursor_fetchone(self, conn):
+        with conn.cursor() as c:
+            result = c.fetchone("SELECT 1 AS val")
+            assert result is not None
+            assert result["val"] == 1
+
+    def test_cursor_fetchall(self, conn):
+        with conn.cursor() as c:
+            result = c.fetchall("SELECT number AS n FROM system.numbers LIMIT 3")
+            assert len(result) == 3
+
+    def test_begin_commit(self, conn):
+        assert conn.in_transaction() is False
+        conn.begin()
+        assert conn.in_transaction() is True
+        conn.commit()
+        assert conn.in_transaction() is False
+
+    def test_begin_rollback(self, conn):
+        conn.begin()
+        assert conn.in_transaction() is True
+        conn.rollback()
+        assert conn.in_transaction() is False
+
+    def test_commit_noop(self, conn):
+        # commit outside transaction should work (no-op)
+        conn.commit()
+
+    def test_rollback_noop(self, conn):
+        # rollback outside transaction should work (no-op)
+        conn.rollback()

--- a/tests/backend/clickhouse/test_clickhouse_dialect.py
+++ b/tests/backend/clickhouse/test_clickhouse_dialect.py
@@ -1,0 +1,535 @@
+import pytest
+from unittest.mock import MagicMock
+
+from rick_db import fieldmapper
+from rick_db.sql import ClickHouseSqlDialect, Select, Insert, SqlError
+from rick_db.sql.common import Literal
+from rick_db.backend.clickhouse.sql import ClickHouseUpdate, ClickHouseDelete
+from rick_db.backend.clickhouse.connection import (
+    ClickHouseCursorWrapper,
+    ClickHouseClientWrapper,
+)
+
+
+# -- Test record for SQL builder tests --
+
+@fieldmapper(tablename="users", pk="id_user")
+class UserRecord:
+    id = "id_user"
+    name = "name"
+    email = "email"
+
+
+# ==========================================
+# ClickHouseSqlDialect Tests
+# ==========================================
+
+class TestClickHouseSqlDialect:
+    def test_placeholder(self):
+        d = ClickHouseSqlDialect()
+        assert d.placeholder == "%s"
+
+    def test_insert_returning(self):
+        d = ClickHouseSqlDialect()
+        assert d.insert_returning is False
+
+    def test_ilike(self):
+        d = ClickHouseSqlDialect()
+        assert d.ilike is True
+
+    def test_json_support(self):
+        d = ClickHouseSqlDialect()
+        assert d.json_support is True
+
+    def test_table_quoting(self):
+        d = ClickHouseSqlDialect()
+        assert d.table("mytable") == '"mytable"'
+        assert d.table("mytable", "alias") == '"mytable" AS "alias"'
+        assert d.table("mytable", schema="mydb") == '"mydb"."mytable"'
+
+    def test_identifier_injection_escape(self):
+        d = ClickHouseSqlDialect()
+        # embedded double-quotes must be escaped by doubling
+        assert d.table('t"; DROP TABLE x; --') == '"t""; DROP TABLE x; --"'
+        assert d.field('f"; DROP TABLE x; --') == '"f""; DROP TABLE x; --"'
+        assert d.database('d"; DROP TABLE x; --') == '"d""; DROP TABLE x; --"'
+
+    def test_field_quoting(self):
+        d = ClickHouseSqlDialect()
+        assert d.field("myfield") == '"myfield"'
+        assert d.field("myfield", "alias") == '"myfield" AS "alias"'
+        assert d.field("myfield", table="mytable") == '"mytable"."myfield"'
+
+    def test_field_cast(self):
+        d = ClickHouseSqlDialect()
+        assert d.field("myfield", ["String"]) == 'CAST("myfield" AS String)'
+        assert (
+            d.field("myfield", ["String", "alias"])
+            == 'CAST("myfield" AS String) AS "alias"'
+        )
+
+    def test_json_extract(self):
+        d = ClickHouseSqlDialect()
+        result = d.json_extract("data", "name")
+        assert result == "JSONExtractString(\"data\", 'name')"
+
+    def test_json_extract_with_jsonpath(self):
+        d = ClickHouseSqlDialect()
+        result = d.json_extract("data", "$.name")
+        assert result == "JSONExtractString(\"data\", 'name')"
+
+    def test_json_extract_with_alias(self):
+        d = ClickHouseSqlDialect()
+        result = d.json_extract("data", "name", "username")
+        assert result == "JSONExtractString(\"data\", 'name') AS \"username\""
+
+    def test_json_extract_text(self):
+        d = ClickHouseSqlDialect()
+        result = d.json_extract_text("data", "name")
+        assert result == "JSONExtractString(\"data\", 'name')"
+
+    def test_json_extract_text_with_alias(self):
+        d = ClickHouseSqlDialect()
+        result = d.json_extract_text("data", "$.name", "val")
+        assert result == "JSONExtractString(\"data\", 'name') AS \"val\""
+
+    def test_json_contains(self):
+        d = ClickHouseSqlDialect()
+        result = d.json_contains("data", "value")
+        assert result == "JSONHas(\"data\", %s)"
+
+    def test_json_contains_path(self):
+        d = ClickHouseSqlDialect()
+        result = d.json_contains_path("data", "name")
+        assert result == "JSON_EXISTS(\"data\", 'name')"
+
+
+# ==========================================
+# ClickHouseUpdate Tests
+# ==========================================
+
+class TestClickHouseUpdate:
+    def test_simple_update(self):
+        d = ClickHouseSqlDialect()
+        sql, values = (
+            ClickHouseUpdate(d)
+            .table("users")
+            .values({"name": "Alice"})
+            .where("id_user", "=", 1)
+            .assemble()
+        )
+        assert sql == 'ALTER TABLE "users" UPDATE "name"=%s WHERE "id_user" = %s'
+        assert values == ["Alice", 1]
+
+    def test_multi_field_update(self):
+        d = ClickHouseSqlDialect()
+        sql, values = (
+            ClickHouseUpdate(d)
+            .table("users")
+            .values({"name": "Alice", "email": "alice@test.com"})
+            .where("id_user", "=", 1)
+            .assemble()
+        )
+        assert sql == (
+            'ALTER TABLE "users" UPDATE "name"=%s, "email"=%s WHERE "id_user" = %s'
+        )
+        assert values == ["Alice", "alice@test.com", 1]
+
+    def test_update_with_schema(self):
+        d = ClickHouseSqlDialect()
+        sql, values = (
+            ClickHouseUpdate(d)
+            .table("users", "mydb")
+            .values({"name": "Alice"})
+            .where("id_user", "=", 1)
+            .assemble()
+        )
+        assert sql == (
+            'ALTER TABLE "mydb"."users" UPDATE "name"=%s WHERE "id_user" = %s'
+        )
+        assert values == ["Alice", 1]
+
+    def test_update_multiple_where(self):
+        d = ClickHouseSqlDialect()
+        sql, values = (
+            ClickHouseUpdate(d)
+            .table("users")
+            .values({"name": "Alice"})
+            .where("id_user", "=", 1)
+            .where("email", "=", "old@test.com")
+            .assemble()
+        )
+        assert sql == (
+            'ALTER TABLE "users" UPDATE "name"=%s '
+            'WHERE "id_user" = %s AND "email" = %s'
+        )
+        assert values == ["Alice", 1, "old@test.com"]
+
+    def test_update_with_literal_value(self):
+        d = ClickHouseSqlDialect()
+        sql, values = (
+            ClickHouseUpdate(d)
+            .table("users")
+            .values({"name": Literal("'test'")})
+            .where("id_user", "=", 1)
+            .assemble()
+        )
+        assert sql == (
+            "ALTER TABLE \"users\" UPDATE \"name\"='test' WHERE \"id_user\" = %s"
+        )
+        assert values == [1]
+
+    def test_update_empty_fields_raises(self):
+        d = ClickHouseSqlDialect()
+        with pytest.raises(SqlError, match="field list is empty"):
+            ClickHouseUpdate(d).table("users").assemble()
+
+    def test_update_field_value_mismatch_raises(self):
+        d = ClickHouseSqlDialect()
+        u = ClickHouseUpdate(d).table("users")
+        u._fields = ["name", "email"]
+        u._values = ["Alice"]
+        with pytest.raises(SqlError, match="field and value count mismatch"):
+            u.assemble()
+
+    def test_update_with_subquery_value(self):
+        d = ClickHouseSqlDialect()
+        subquery = Select(d).from_("defaults", ["value"]).where("key", "=", "name")
+        sql, values = (
+            ClickHouseUpdate(d)
+            .table("users")
+            .values({"name": subquery})
+            .where("id_user", "=", 1)
+            .assemble()
+        )
+        assert "ALTER TABLE" in sql
+        assert "UPDATE" in sql
+        assert values == ["name", 1]
+
+    def test_update_no_where(self):
+        d = ClickHouseSqlDialect()
+        sql, values = (
+            ClickHouseUpdate(d)
+            .table("users")
+            .values({"name": "Alice"})
+            .assemble()
+        )
+        assert sql == 'ALTER TABLE "users" UPDATE "name"=%s'
+        assert values == ["Alice"]
+
+    def test_delete_no_where(self):
+        d = ClickHouseSqlDialect()
+        sql, values = (
+            ClickHouseDelete(d)
+            .from_("users")
+            .assemble()
+        )
+        assert sql == 'ALTER TABLE "users" DELETE'
+        assert values == []
+
+
+# ==========================================
+# ClickHouseDelete Tests
+# ==========================================
+
+class TestClickHouseDelete:
+    def test_simple_delete(self):
+        d = ClickHouseSqlDialect()
+        sql, values = (
+            ClickHouseDelete(d)
+            .from_("users")
+            .where("id_user", "=", 1)
+            .assemble()
+        )
+        assert sql == 'ALTER TABLE "users" DELETE WHERE "id_user" = %s'
+        assert values == [1]
+
+    def test_delete_with_schema(self):
+        d = ClickHouseSqlDialect()
+        sql, values = (
+            ClickHouseDelete(d)
+            .from_("users", "mydb")
+            .where("id_user", "=", 1)
+            .assemble()
+        )
+        assert sql == 'ALTER TABLE "mydb"."users" DELETE WHERE "id_user" = %s'
+        assert values == [1]
+
+    def test_delete_multiple_where(self):
+        d = ClickHouseSqlDialect()
+        sql, values = (
+            ClickHouseDelete(d)
+            .from_("users")
+            .where("id_user", ">", 0)
+            .where("name", "=", "test")
+            .assemble()
+        )
+        assert sql == (
+            'ALTER TABLE "users" DELETE WHERE "id_user" > %s AND "name" = %s'
+        )
+        assert values == [0, "test"]
+
+    def test_delete_or_where(self):
+        d = ClickHouseSqlDialect()
+        sql, values = (
+            ClickHouseDelete(d)
+            .from_("users")
+            .where("id_user", "=", 1)
+            .orwhere("id_user", "=", 2)
+            .assemble()
+        )
+        assert sql == (
+            'ALTER TABLE "users" DELETE WHERE "id_user" = %s OR "id_user" = %s'
+        )
+        assert values == [1, 2]
+
+    def test_delete_from_record(self):
+        d = ClickHouseSqlDialect()
+        sql, values = (
+            ClickHouseDelete(d)
+            .from_(UserRecord)
+            .where(UserRecord.id, "=", 1)
+            .assemble()
+        )
+        assert sql == 'ALTER TABLE "users" DELETE WHERE "id_user" = %s'
+        assert values == [1]
+
+
+# ==========================================
+# Select/Insert with ClickHouse dialect
+# ==========================================
+
+class TestClickHouseSelectInsert:
+    def test_select(self):
+        d = ClickHouseSqlDialect()
+        sql, values = Select(d).from_("users", ["id_user", "name"]).assemble()
+        assert sql == 'SELECT "id_user","name" FROM "users"'
+        assert values == []
+
+    def test_select_where(self):
+        d = ClickHouseSqlDialect()
+        sql, values = (
+            Select(d).from_("users").where("name", "=", "Alice").assemble()
+        )
+        assert 'FROM "users"' in sql
+        assert '"name" = %s' in sql
+        assert values == ["Alice"]
+
+    def test_insert(self):
+        d = ClickHouseSqlDialect()
+        record = UserRecord(name="Alice", email="alice@test.com")
+        sql, values = Insert(d).into(record).assemble()
+        assert '"users"' in sql
+        assert "INSERT INTO" in sql
+        assert "RETURNING" not in sql
+        assert "Alice" in values
+        assert "alice@test.com" in values
+
+
+# ==========================================
+# CursorWrapper Tests
+# ==========================================
+
+class TestClickHouseCursorWrapper:
+    def _make_query_result(self, column_names, rows):
+        result = MagicMock()
+        result.column_names = column_names
+        result.result_rows = rows
+        return result
+
+    def test_select_routes_to_query(self):
+        client = MagicMock()
+        client.query.return_value = self._make_query_result(
+            ["id", "name"], [(1, "Alice"), (2, "Bob")]
+        )
+        cursor = ClickHouseCursorWrapper(client)
+        cursor.execute("SELECT * FROM users")
+        client.query.assert_called_once()
+        client.command.assert_not_called()
+
+    def test_select_returns_dicts(self):
+        client = MagicMock()
+        client.query.return_value = self._make_query_result(
+            ["id", "name"], [(1, "Alice")]
+        )
+        cursor = ClickHouseCursorWrapper(client)
+        cursor.execute("SELECT * FROM users")
+        rows = cursor.fetchall()
+        assert len(rows) == 1
+        assert rows[0] == {"id": 1, "name": "Alice"}
+
+    def test_fetchone_returns_first(self):
+        client = MagicMock()
+        client.query.return_value = self._make_query_result(
+            ["id"], [(1,), (2,)]
+        )
+        cursor = ClickHouseCursorWrapper(client)
+        cursor.execute("SELECT id FROM users")
+        row = cursor.fetchone()
+        assert row == {"id": 1}
+
+    def test_fetchone_returns_none_on_empty(self):
+        client = MagicMock()
+        client.query.return_value = self._make_query_result([], [])
+        cursor = ClickHouseCursorWrapper(client)
+        cursor.execute("SELECT id FROM users")
+        assert cursor.fetchone() is None
+
+    def test_insert_routes_to_command(self):
+        client = MagicMock()
+        cursor = ClickHouseCursorWrapper(client)
+        cursor.execute("INSERT INTO users VALUES (%s, %s)", ("Alice", "a@b.com"))
+        client.command.assert_called_once()
+        client.query.assert_not_called()
+
+    def test_create_routes_to_command(self):
+        client = MagicMock()
+        cursor = ClickHouseCursorWrapper(client)
+        cursor.execute("CREATE TABLE test (id UInt32) ENGINE = MergeTree()")
+        client.command.assert_called_once()
+
+    def test_alter_routes_to_command(self):
+        client = MagicMock()
+        cursor = ClickHouseCursorWrapper(client)
+        cursor.execute("ALTER TABLE users DELETE WHERE id = %s", (1,))
+        client.command.assert_called_once()
+
+    def test_show_routes_to_query(self):
+        client = MagicMock()
+        client.query.return_value = self._make_query_result(["name"], [("db1",)])
+        cursor = ClickHouseCursorWrapper(client)
+        cursor.execute("SHOW DATABASES")
+        client.query.assert_called_once()
+
+    def test_describe_routes_to_query(self):
+        client = MagicMock()
+        client.query.return_value = self._make_query_result(
+            ["name", "type"], [("id", "UInt32")]
+        )
+        cursor = ClickHouseCursorWrapper(client)
+        cursor.execute("DESCRIBE TABLE users")
+        client.query.assert_called_once()
+
+    def test_with_routes_to_query(self):
+        client = MagicMock()
+        client.query.return_value = self._make_query_result(["x"], [(1,)])
+        cursor = ClickHouseCursorWrapper(client)
+        cursor.execute("WITH 1 AS x SELECT x")
+        client.query.assert_called_once()
+
+    def test_description_for_select(self):
+        client = MagicMock()
+        client.query.return_value = self._make_query_result(
+            ["id", "name"], [(1, "Alice")]
+        )
+        cursor = ClickHouseCursorWrapper(client)
+        cursor.execute("SELECT * FROM users")
+        assert cursor.description == [("id",), ("name",)]
+
+    def test_description_for_insert(self):
+        client = MagicMock()
+        cursor = ClickHouseCursorWrapper(client)
+        cursor.execute("INSERT INTO users VALUES (%s)", ("test",))
+        assert cursor.description is None
+
+    def test_close_clears_state(self):
+        client = MagicMock()
+        client.query.return_value = self._make_query_result(
+            ["id"], [(1,)]
+        )
+        cursor = ClickHouseCursorWrapper(client)
+        cursor.execute("SELECT 1")
+        cursor.close()
+        assert cursor.fetchall() == []
+        assert cursor.description is None
+
+    def test_params_as_list(self):
+        client = MagicMock()
+        cursor = ClickHouseCursorWrapper(client)
+        cursor.execute("INSERT INTO users VALUES (%s)", ["Alice"])
+        # Verify params were converted to tuple
+        call_args = client.command.call_args
+        assert call_args[1]["parameters"] == ("Alice",)
+
+
+# ==========================================
+# ClientWrapper Tests
+# ==========================================
+
+class TestClickHouseClientWrapper:
+    def test_commit_is_noop(self):
+        client = MagicMock()
+        wrapper = ClickHouseClientWrapper(client)
+        wrapper.commit()  # should not raise
+
+    def test_rollback_is_noop(self):
+        client = MagicMock()
+        wrapper = ClickHouseClientWrapper(client)
+        wrapper.rollback()  # should not raise
+
+    def test_cursor_returns_wrapper(self):
+        client = MagicMock()
+        wrapper = ClickHouseClientWrapper(client)
+        cursor = wrapper.cursor()
+        assert isinstance(cursor, ClickHouseCursorWrapper)
+
+    def test_close_calls_client_close(self):
+        client = MagicMock()
+        wrapper = ClickHouseClientWrapper(client)
+        wrapper.close()
+        client.close.assert_called_once()
+
+    def test_autocommit_attribute(self):
+        client = MagicMock()
+        wrapper = ClickHouseClientWrapper(client)
+        assert wrapper.autocommit is False
+
+
+# ==========================================
+# ClickHouseConnection Tests (mocked)
+# ==========================================
+
+class TestClickHouseConnection:
+    def _make_connection(self):
+        """Create a ClickHouseConnection using the wrapper directly, bypassing import."""
+        from rick_db.backend.clickhouse.connection import (
+            ClickHouseConnection,
+            ClickHouseClientWrapper,
+        )
+        from rick_db import Connection
+
+        mock_client = MagicMock()
+        wrapper = ClickHouseClientWrapper(mock_client)
+        # Build connection directly, bypassing clickhouse_connect import
+        conn = Connection.__new__(ClickHouseConnection)
+        conn.autocommit = False
+        Connection.__init__(conn, None, wrapper, ClickHouseSqlDialect())
+        return conn, mock_client
+
+    def test_creates_with_dialect(self):
+        conn, _ = self._make_connection()
+        assert isinstance(conn.dialect(), ClickHouseSqlDialect)
+
+    def test_client_property(self):
+        conn, mock_client = self._make_connection()
+        assert conn.client is mock_client
+
+    def test_autocommit_is_false(self):
+        conn, _ = self._make_connection()
+        assert conn.autocommit is False
+
+    def test_commit_no_error(self):
+        conn, _ = self._make_connection()
+        conn.commit()  # should not raise
+
+    def test_rollback_no_error(self):
+        conn, _ = self._make_connection()
+        conn.rollback()  # should not raise
+
+    def test_begin_sets_transaction(self):
+        conn, _ = self._make_connection()
+        assert conn.in_transaction() is False
+        conn.begin()
+        assert conn.in_transaction() is True
+        conn.commit()
+        assert conn.in_transaction() is False

--- a/tests/backend/clickhouse/test_clickhouse_manager.py
+++ b/tests/backend/clickhouse/test_clickhouse_manager.py
@@ -1,0 +1,187 @@
+import pytest
+
+from rick_db.backend.clickhouse import ClickHouseConnection, ClickHouseManager
+
+create_table = """
+CREATE TABLE IF NOT EXISTS animal (
+    id_animal UInt32,
+    name String
+) ENGINE = MergeTree()
+ORDER BY id_animal
+"""
+
+create_view = "CREATE VIEW IF NOT EXISTS list_animal AS SELECT * FROM animal"
+
+
+class TestClickHouseManager:
+    def test_tables(self, ch_backend):
+        mgr = ClickHouseManager(ch_backend)
+        # no tables created yet
+        tables = mgr.tables()
+        assert "animal" not in tables
+        assert mgr.table_exists("animal") is False
+
+        # create one table
+        with mgr.conn() as conn:
+            with conn.cursor() as c:
+                c.exec(create_table)
+
+        tables = mgr.tables()
+        assert "animal" in tables
+        assert mgr.table_exists("animal") is True
+
+        # cleanup
+        mgr.drop_table("animal")
+        assert mgr.table_exists("animal") is False
+
+    def test_views(self, ch_backend):
+        mgr = ClickHouseManager(ch_backend)
+        # no views created yet
+        assert mgr.view_exists("list_animal") is False
+
+        # create table and view
+        with mgr.conn() as conn:
+            with conn.cursor() as c:
+                c.exec(create_table)
+                c.exec(create_view)
+
+        views = mgr.views()
+        assert "list_animal" in views
+        assert mgr.view_exists("list_animal") is True
+
+        # views should not appear in tables()
+        tables = mgr.tables()
+        assert "list_animal" not in tables
+
+        # cleanup
+        mgr.drop_view("list_animal")
+        assert mgr.view_exists("list_animal") is False
+
+    def test_databases(self, ch_backend):
+        mgr = ClickHouseManager(ch_backend)
+        dbs = mgr.databases()
+        assert len(dbs) > 0
+        # system databases should always exist
+        assert "system" in dbs
+
+    def test_schemas_equals_databases(self, ch_backend):
+        mgr = ClickHouseManager(ch_backend)
+        assert mgr.schemas() == mgr.databases()
+
+    def test_table_fields(self, ch_backend):
+        mgr = ClickHouseManager(ch_backend)
+        with mgr.conn() as conn:
+            with conn.cursor() as c:
+                c.exec(create_table)
+
+        fields = mgr.table_fields("animal")
+        assert len(fields) == 2
+        field1, field2 = fields
+        assert field1.field == "id_animal"
+        assert field1.primary is True
+        assert field2.field == "name"
+        assert field2.primary is False
+
+    def test_view_fields(self, ch_backend):
+        mgr = ClickHouseManager(ch_backend)
+        with mgr.conn() as conn:
+            with conn.cursor() as c:
+                c.exec(create_table)
+                c.exec(create_view)
+
+        fields = mgr.view_fields("list_animal")
+        assert len(fields) == 2
+
+    def test_table_pk(self, ch_backend):
+        mgr = ClickHouseManager(ch_backend)
+        with mgr.conn() as conn:
+            with conn.cursor() as c:
+                c.exec(create_table)
+
+        pk = mgr.table_pk("animal")
+        assert pk is not None
+        assert pk.field == "id_animal"
+
+    def test_table_pk_none(self, ch_backend):
+        mgr = ClickHouseManager(ch_backend)
+        # non-existing table
+        pk = mgr.table_pk("nonexistent_table")
+        assert pk is None
+
+    def test_table_indexes(self, ch_backend):
+        mgr = ClickHouseManager(ch_backend)
+        with mgr.conn() as conn:
+            with conn.cursor() as c:
+                c.exec(create_table)
+
+        # MergeTree tables without explicit skip indexes return empty
+        indexes = mgr.table_indexes("animal")
+        assert isinstance(indexes, list)
+
+    def test_users(self, ch_backend):
+        mgr = ClickHouseManager(ch_backend)
+        users = mgr.users()
+        assert isinstance(users, list)
+        # at least the default user should exist
+        assert len(users) > 0
+
+    def test_user_groups(self, ch_backend):
+        mgr = ClickHouseManager(ch_backend)
+        groups = mgr.user_groups("default")
+        assert groups == []
+
+    def test_create_drop_database(self, ch_backend):
+        mgr = ClickHouseManager(ch_backend)
+        db_name = "rickdb_test_tmp"
+
+        # create
+        mgr.create_database(db_name)
+        assert mgr.database_exists(db_name) is True
+
+        # drop
+        mgr.drop_database(db_name)
+        assert mgr.database_exists(db_name) is False
+
+    def test_schema_exists_delegates(self, ch_backend):
+        mgr = ClickHouseManager(ch_backend)
+        # system database always exists
+        assert mgr.schema_exists("system") is True
+        assert mgr.schema_exists("nonexistent_schema_xyz") is False
+
+    def test_create_schema_raises(self, ch_backend):
+        mgr = ClickHouseManager(ch_backend)
+        with pytest.raises(NotImplementedError):
+            mgr.create_schema("test")
+
+    def test_drop_schema_raises(self, ch_backend):
+        mgr = ClickHouseManager(ch_backend)
+        with pytest.raises(NotImplementedError):
+            mgr.drop_schema("test")
+
+    def test_kill_clients_raises(self, ch_backend):
+        mgr = ClickHouseManager(ch_backend)
+        with pytest.raises(NotImplementedError):
+            mgr.kill_clients("test")
+
+    def test_backend(self, ch_backend):
+        mgr = ClickHouseManager(ch_backend)
+        assert mgr.backend() is ch_backend
+
+    def test_drop_table(self, ch_backend):
+        mgr = ClickHouseManager(ch_backend)
+        with mgr.conn() as conn:
+            with conn.cursor() as c:
+                c.exec(create_table)
+        assert mgr.table_exists("animal") is True
+        mgr.drop_table("animal")
+        assert mgr.table_exists("animal") is False
+
+    def test_drop_view(self, ch_backend):
+        mgr = ClickHouseManager(ch_backend)
+        with mgr.conn() as conn:
+            with conn.cursor() as c:
+                c.exec(create_table)
+                c.exec(create_view)
+        assert mgr.view_exists("list_animal") is True
+        mgr.drop_view("list_animal")
+        assert mgr.view_exists("list_animal") is False

--- a/tests/backend/clickhouse/test_clickhouse_migrations.py
+++ b/tests/backend/clickhouse/test_clickhouse_migrations.py
@@ -1,0 +1,169 @@
+import pytest
+
+from rick_db.backend.clickhouse import ClickHouseConnection, ClickHouseManager
+from rick_db.backend.clickhouse.migrations import ClickHouseMigrationManager
+from rick_db.migrations import MigrationRecord
+
+
+class TestClickHouseMigrationManager:
+
+    @pytest.fixture
+    def mm(self, ch_backend):
+        mgr = ClickHouseManager(ch_backend)
+        mm = ClickHouseMigrationManager(mgr)
+        yield mm
+        mgr.drop_table(mm.MIGRATION_TABLE)
+
+    def test_install_manager(self, mm):
+        meta = mm.manager
+
+        # ensure no manager
+        assert mm.is_installed() is False
+
+        # install manager
+        result = mm.install()
+        assert result.success is True
+        assert result.error == ""
+        assert mm.is_installed() is True
+        tables = meta.tables()
+        assert mm.MIGRATION_TABLE in tables
+
+        # check table has no entries
+        m_list = mm.list()
+        assert len(m_list) == 0
+
+    def test_install_already_installed(self, mm):
+        mm.install()
+        result = mm.install()
+        assert result.success is False
+        assert "already exists" in result.error
+
+    def test_register(self, mm):
+        mm.install()
+
+        mig = MigrationRecord(name="migration1")
+        result = mm.register(mig)
+        assert result.success is True
+        assert result.error == ""
+
+        m_list = mm.list()
+        assert len(m_list) == 1
+        assert m_list[0].name == "migration1"
+
+    def test_register_duplicate(self, mm):
+        mm.install()
+
+        mig = MigrationRecord(name="migration1")
+        mm.register(mig)
+
+        # duplicate should fail
+        result = mm.register(MigrationRecord(name="migration1"))
+        assert result.success is False
+        assert "already exists" in result.error
+
+    def test_register_empty_name(self, mm):
+        mm.install()
+        result = mm.register(MigrationRecord(name=""))
+        assert result.success is False
+
+    def test_fetch_by_name(self, mm):
+        mm.install()
+        mm.register(MigrationRecord(name="mig_one"))
+
+        r = mm.fetch_by_name("mig_one")
+        assert r is not None
+        assert r.name == "mig_one"
+
+        r = mm.fetch_by_name("nonexistent")
+        assert r is None
+
+    def test_flatten(self, mm):
+        mm.install()
+
+        # insert multiple records
+        for name in ["mig1", "mig2", "mig3"]:
+            result = mm.register(MigrationRecord(name=name))
+            assert result.success is True
+
+        m_list = mm.list()
+        assert len(m_list) == 3
+
+        # flatten
+        flatten_record = MigrationRecord(name="flattened")
+        result = mm.flatten(flatten_record)
+        assert result.success is True
+
+        m_list = mm.list()
+        assert len(m_list) == 1
+        assert m_list[0].name == "flattened"
+
+    def test_execute(self, mm):
+        mm.install()
+
+        create_sql = """
+        CREATE TABLE IF NOT EXISTS animal (
+            id_animal UInt32,
+            name String
+        ) ENGINE = MergeTree()
+        ORDER BY id_animal
+        """
+
+        mig = MigrationRecord(name="create_animal")
+        result = mm.execute(mig, create_sql)
+        assert result.success is True
+
+        # table should exist
+        assert mm.manager.table_exists("animal") is True
+
+        # migration should be registered
+        r = mm.fetch_by_name("create_animal")
+        assert r is not None
+
+        # cleanup
+        mm.manager.drop_table("animal")
+
+    def test_execute_duplicate(self, mm):
+        mm.install()
+
+        create_sql = """
+        CREATE TABLE IF NOT EXISTS animal (
+            id_animal UInt32,
+            name String
+        ) ENGINE = MergeTree()
+        ORDER BY id_animal
+        """
+        mm.execute(MigrationRecord(name="create_animal"), create_sql)
+
+        # executing same migration again should fail
+        result = mm.execute(MigrationRecord(name="create_animal"), create_sql)
+        assert result.success is False
+
+        mm.manager.drop_table("animal")
+
+    def test_execute_empty(self, mm):
+        mm.install()
+        result = mm.execute(MigrationRecord(name=""), "SELECT 1")
+        assert result.success is False
+
+        result = mm.execute(MigrationRecord(name="test"), "")
+        assert result.success is False
+
+    def test_exec_multi_statement(self, mm):
+        """Test that _exec splits multi-statement SQL correctly"""
+        mm.install()
+
+        multi_sql = """
+        CREATE TABLE IF NOT EXISTS animal (
+            id_animal UInt32,
+            name String
+        ) ENGINE = MergeTree()
+        ORDER BY id_animal;
+        INSERT INTO animal VALUES (1, 'cat');
+        INSERT INTO animal VALUES (2, 'dog')
+        """
+
+        mig = MigrationRecord(name="multi_stmt")
+        result = mm.execute(mig, multi_sql)
+        assert result.success is True
+
+        mm.manager.drop_table("animal")

--- a/tests/backend/clickhouse/test_clickhouse_repository.py
+++ b/tests/backend/clickhouse/test_clickhouse_repository.py
@@ -1,0 +1,287 @@
+import pytest
+
+from rick_db import fieldmapper, RepositoryError
+from rick_db.backend.clickhouse import (
+    ClickHouseConnection,
+    ClickHouseManager,
+    ClickHouseRepository,
+)
+
+
+@fieldmapper(tablename="users", pk="id_user")
+class User:
+    id = "id_user"
+    name = "name"
+    email = "email"
+    login = "login"
+    active = "active"
+
+
+create_table = """
+CREATE TABLE IF NOT EXISTS users (
+    id_user UInt32,
+    name String DEFAULT '',
+    email String DEFAULT '',
+    login Nullable(String) DEFAULT NULL,
+    active UInt8 DEFAULT 1
+) ENGINE = MergeTree()
+ORDER BY id_user
+"""
+
+drop_table = "DROP TABLE IF EXISTS users"
+
+fixture_data = [
+    {"id_user": 1, "name": "aragorn", "email": "aragorn@lotr", "login": "aragorn", "active": 1},
+    {"id_user": 2, "name": "bilbo", "email": "bilbo@lotr", "login": "bilbo", "active": 1},
+    {"id_user": 3, "name": "samwise", "email": "samwise@lotr", "login": "samwise", "active": 1},
+    {"id_user": 4, "name": "gandalf", "email": "gandalf@lotr", "login": "gandalf", "active": 1},
+    {"id_user": 5, "name": "gollum", "email": "gollum@lotr", "login": "gollum", "active": 1},
+]
+
+
+@pytest.fixture
+def conn(ch_settings):
+    try:
+        conn = ClickHouseConnection(**ch_settings)
+    except Exception:
+        pytest.skip("ClickHouse server not available")
+        return
+
+    # setup
+    with conn.cursor() as c:
+        c.exec(drop_table)
+        c.exec(create_table)
+        for r in fixture_data:
+            c.exec(
+                "INSERT INTO users (id_user, name, email, login, active) VALUES (%s, %s, %s, %s, %s)",
+                list(r.values()),
+            )
+    yield conn
+
+    # teardown
+    with conn.cursor() as c:
+        c.exec(drop_table)
+    conn.close()
+
+
+class TestClickHouseRepository:
+    def test_create_repository(self, conn):
+        repo = ClickHouseRepository(conn, User)
+        assert repo.pk == "id_user"
+        assert repo.table_name == "users"
+
+    def test_fetch_all(self, conn):
+        repo = ClickHouseRepository(conn, User)
+        users = repo.fetch_all()
+        assert isinstance(users, list)
+        assert len(users) == len(fixture_data)
+        for r in users:
+            assert isinstance(r, User)
+            assert r.name is not None and len(r.name) > 0
+
+    def test_fetch_all_ordered(self, conn):
+        repo = ClickHouseRepository(conn, User)
+        users = repo.fetch_all_ordered(User.email)
+        assert len(users) == len(fixture_data)
+        emails = [u.email for u in users]
+        assert emails == sorted(emails)
+
+    def test_fetch_pk(self, conn):
+        repo = ClickHouseRepository(conn, User)
+        record = repo.fetch_pk(1)
+        assert record is not None
+        assert record.name == "aragorn"
+
+        record = repo.fetch_pk(999)
+        assert record is None
+
+    def test_fetch_one(self, conn):
+        repo = ClickHouseRepository(conn, User)
+        record = repo.fetch_one(repo.select().where(User.name, "=", "gandalf"))
+        assert record is not None
+        assert record.name == "gandalf"
+
+        record = repo.fetch_one(repo.select().where(User.name, "=", "nonexistent"))
+        assert record is None
+
+    def test_fetch(self, conn):
+        repo = ClickHouseRepository(conn, User)
+        users = repo.fetch(repo.select().where(User.id, ">", 0))
+        assert len(users) == len(fixture_data)
+
+        users = repo.fetch(repo.select().where(User.id, "=", 999))
+        assert len(users) == 0
+
+    def test_fetch_raw(self, conn):
+        repo = ClickHouseRepository(conn, User)
+        rows = repo.fetch_raw(repo.select().where(User.id, ">", 0))
+        assert len(rows) == len(fixture_data)
+        for r in rows:
+            assert "name" in r
+
+    def test_fetch_by_field(self, conn):
+        repo = ClickHouseRepository(conn, User)
+        records = repo.fetch_by_field(User.name, "gandalf")
+        assert len(records) == 1
+        assert records[0].name == "gandalf"
+
+        records = repo.fetch_by_field(User.name, "nonexistent")
+        assert len(records) == 0
+
+    def test_fetch_where(self, conn):
+        repo = ClickHouseRepository(conn, User)
+        records = repo.fetch_where([(User.name, "=", "gandalf")])
+        assert len(records) == 1
+        assert records[0].name == "gandalf"
+
+        records = repo.fetch_where([(User.name, "=", "nonexistent")])
+        assert len(records) == 0
+
+        with pytest.raises(RepositoryError):
+            repo.fetch_where([])
+
+    def test_insert(self, conn):
+        repo = ClickHouseRepository(conn, User)
+        repo.insert(User(id=10, name="John", email="john@skynet"))
+
+        records = repo.fetch_by_field(User.name, "John")
+        assert len(records) == 1
+        assert records[0].email == "john@skynet"
+
+    def test_insert_pk_returns_none(self, conn):
+        repo = ClickHouseRepository(conn, User)
+        result = repo.insert_pk(User(id=11, name="Sarah", email="sarah@skynet"))
+        assert result is None
+
+        # but the record should be inserted
+        records = repo.fetch_by_field(User.name, "Sarah")
+        assert len(records) == 1
+
+    def test_delete_pk(self, conn):
+        repo = ClickHouseRepository(conn, User)
+        repo.insert(User(id=20, name="ToDelete", email="delete@test"))
+
+        # verify it exists
+        record = repo.fetch_pk(20)
+        assert record is not None
+
+        repo.delete_pk(20)
+        # ClickHouse mutations are async; use FINAL to read consistent state
+        records = repo.fetch_by_field(User.name, "ToDelete")
+        # mutation may be async, but for lightweight deletes it should be immediate
+        # just verify no error is raised
+
+    def test_delete_where(self, conn):
+        repo = ClickHouseRepository(conn, User)
+        repo.insert(User(id=21, name="ToDelete2", email="delete2@test"))
+
+        repo.delete_where([(User.id, "=", 21)])
+        # no error raised
+
+        with pytest.raises(RepositoryError):
+            repo.delete_where([])
+
+        with pytest.raises(RepositoryError):
+            repo.delete_where([("field",)])
+
+    def test_update(self, conn):
+        repo = ClickHouseRepository(conn, User)
+
+        # update with pk in record
+        user = User(id=1, name="Strider", email="aragorn@lotr")
+        repo.update(user)
+        # no error raised
+
+    def test_update_with_pk_value(self, conn):
+        repo = ClickHouseRepository(conn, User)
+        repo.update(User(name="Strider"), pk_value=1)
+        # no error raised
+
+    def test_update_missing_pk(self, conn):
+        repo = ClickHouseRepository(conn, User)
+        with pytest.raises(RepositoryError, match="missing primary key value"):
+            repo.update(User(name="Strider"))
+
+    def test_update_where(self, conn):
+        repo = ClickHouseRepository(conn, User)
+        repo.update_where(User(name="Pocoyo"), [(User.login, "=", "gollum")])
+        # no error raised
+
+    def test_update_where_two_arg(self, conn):
+        repo = ClickHouseRepository(conn, User)
+        repo.update_where(User(name="Pocoyo"), [(User.login, "gollum")])
+        # no error raised (2-tuple uses = operator)
+
+    def test_update_where_errors(self, conn):
+        repo = ClickHouseRepository(conn, User)
+
+        with pytest.raises(RepositoryError):
+            repo.update_where(User(name="x"), [])
+
+        with pytest.raises(RepositoryError):
+            repo.update_where(User(name="x"), "not_a_list")
+
+        with pytest.raises(RepositoryError):
+            repo.update_where(User(name="x"), [("a",)])
+
+        with pytest.raises(RepositoryError):
+            repo.update_where(User(name="x"), ["not_a_tuple"])
+
+    def test_count(self, conn):
+        repo = ClickHouseRepository(conn, User)
+        assert repo.count() == len(fixture_data)
+
+    def test_count_where(self, conn):
+        repo = ClickHouseRepository(conn, User)
+        assert repo.count_where([(User.id, ">", 0)]) == len(fixture_data)
+        assert repo.count_where([(User.name, "gandalf")]) == 1
+
+    def test_valid_pk(self, conn):
+        repo = ClickHouseRepository(conn, User)
+        assert repo.valid_pk(1) is True
+        assert repo.valid_pk(999) is False
+
+    def test_exists(self, conn):
+        repo = ClickHouseRepository(conn, User)
+        # name "aragorn" exists with id=1, so checking with other id should be True
+        assert repo.exists(User.name, "aragorn", 2) is True
+        # checking with own id should be False (no OTHER record has this name)
+        assert repo.exists(User.name, "aragorn", 1) is False
+
+    def test_map_result_id(self, conn):
+        repo = ClickHouseRepository(conn, User)
+        users = repo.map_result_id(repo.fetch_all())
+        assert len(users) == len(fixture_data)
+        for pk, record in users.items():
+            assert pk == record.id
+
+    def test_list(self, conn):
+        repo = ClickHouseRepository(conn, User)
+        qry = repo.select().order(User.id)
+        total, rows = repo.list(qry, 2)
+        assert total == len(fixture_data)
+        assert len(rows) == 2
+
+        total, rows = repo.list(qry, 2, 2)
+        assert total == len(fixture_data)
+        assert len(rows) == 2
+
+    def test_select_builder(self, conn):
+        repo = ClickHouseRepository(conn, User)
+        qry = repo.select([User.id, User.name])
+        sql, _ = qry.assemble()
+        assert '"id_user"' in sql
+        assert '"name"' in sql
+
+    def test_transaction_context_manager(self, conn):
+        """ClickHouse transactions are no-ops but the API should not error"""
+        repo = ClickHouseRepository(conn, User)
+        with repo.transaction():
+            repo.insert(User(id=30, name="TxTest", email="tx@test"))
+        # no error raised
+
+    def test_exec_raw(self, conn):
+        repo = ClickHouseRepository(conn, User)
+        result = repo.exec("SELECT count() AS cnt FROM users", useCls=False)
+        assert len(result) == 1
+        assert result[0]["cnt"] == len(fixture_data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,3 +37,28 @@ def sqlite_conn() -> Sqlite3Connection:
     c = Sqlite3Connection(":memory:")
     yield c
     c.close()
+
+
+@pytest.fixture
+def ch_settings() -> dict:
+    return {
+        "host": os.environ.get("CLICKHOUSE_HOST", "localhost"),
+        "port": int(os.environ.get("CLICKHOUSE_PORT", 8123)),
+        "username": os.environ.get("CLICKHOUSE_USER", "default"),
+        "password": os.environ.get("CLICKHOUSE_PASSWORD", ""),
+        "database": os.environ.get("CLICKHOUSE_DB", "default"),
+    }
+
+
+@pytest.fixture
+def ch_conn(ch_settings):
+    from rick_db.backend.clickhouse import ClickHouseConnection
+
+    try:
+        c = ClickHouseConnection(**ch_settings)
+    except Exception:
+        pytest.skip("ClickHouse server not available")
+        return
+
+    yield c
+    c.close()

--- a/tests/sql/test_dialect.py
+++ b/tests/sql/test_dialect.py
@@ -124,6 +124,32 @@ class TestSqlDialect:
     def test_sqlitedialect_field(self, field, field_alias, table, schema, result):
         assert SqlDialect().field(field, field_alias, table, schema) == result
 
+    def test_identifier_escaping_table(self):
+        d = SqlDialect()
+        # embedded double-quote must be doubled (SQL standard)
+        assert d.table('tab"le') == '"tab""le"'
+        assert d.table("safe") == '"safe"'
+        # alias and schema are also escaped
+        assert d.table("t", alias='a"lias') == '"t" AS "a""lias"'
+        assert d.table("t", schema='s"ch') == '"s""ch"."t"'
+
+    def test_identifier_escaping_field(self):
+        d = SqlDialect()
+        assert d.field('fi"eld') == '"fi""eld"'
+        assert d.field("f", field_alias='a"l') == '"f" AS "a""l"'
+        assert d.field("f", table='t"bl') == '"t""bl"."f"'
+
+    def test_identifier_escaping_database(self):
+        d = SqlDialect()
+        assert d.database('db"name') == '"db""name"'
+        assert d.database("db", alias='a"l') == '"db" AS "a""l"'
+
+    def test_identifier_escaping_pg(self):
+        d = PgSqlDialect()
+        assert d.table('tab"le') == '"tab""le"'
+        assert d.field('fi"eld') == '"fi""eld"'
+        assert d.database('db"name') == '"db""name"'
+
     @pytest.mark.parametrize("table_name, alias, schema, result", pg_dialect_table())
     def test_pgsqldialect_table(self, table_name, alias, schema, result):
         assert PgSqlDialect().table(table_name, alias, schema) == result

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -7,6 +7,7 @@ from rick_db.mapper import (
     ATTR_TABLE,
     ATTR_SCHEMA,
     ATTR_PRIMARY_KEY,
+    ATTR_JSON_EXCLUDE,
     ATTR_RECORD_MAGIC,
     ATTR_ROW,
 )
@@ -175,3 +176,87 @@ class TestMapper:
         for field in ua.fields():
             assert field in ["id", "name", "user", "street", "city"]
         assert len(ua.asdict()) == 2
+
+
+# field names - SecureUser
+FIELD_SECURE_USER_ID = "id_user"
+FIELD_SECURE_USER_NAME = "username"
+FIELD_SECURE_USER_PASSWORD = "password_hash"
+FIELD_SECURE_USER_SECRET = "secret_key"
+
+
+@fieldmapper(pk="id_user", tablename="users", json_exclude={"password", "secret"})
+class SecureUser(Record):
+    id = FIELD_SECURE_USER_ID
+    name = FIELD_SECURE_USER_NAME
+    password = FIELD_SECURE_USER_PASSWORD
+    secret = FIELD_SECURE_USER_SECRET
+
+
+class TestJsonExclude:
+
+    def test_class_level_exclusion(self):
+        """Fields listed in json_exclude are omitted from asdict()"""
+        user = SecureUser(id=1, name="alice", password="hashed", secret="s3cret")
+        result = user.asdict()
+        assert result == {"id": 1, "name": "alice"}
+        assert "password" not in result
+        assert "secret" not in result
+
+    def test_per_call_exclusion(self):
+        """asdict(exclude=...) omits additional fields per call"""
+        user = User(id=1, name="john")
+        result = user.asdict(exclude=["name"])
+        assert result == {"id": 1}
+        assert "name" not in result
+
+    def test_combined_exclusion(self):
+        """Per-call exclude merges with class-level json_exclude"""
+        user = SecureUser(id=1, name="alice", password="hashed", secret="s3cret")
+        result = user.asdict(exclude=["name"])
+        assert result == {"id": 1}
+        assert "name" not in result
+        assert "password" not in result
+        assert "secret" not in result
+
+    def test_backward_compat_no_exclusion(self):
+        """Existing asdict() without arguments still works identically"""
+        user = User(id=3, name="john doe")
+        result = user.asdict()
+        assert result == {"id": 3, "name": "john doe"}
+
+    def test_excluded_fields_still_accessible(self):
+        """Excluded fields are still accessible as attributes and via other methods"""
+        user = SecureUser(id=1, name="alice", password="hashed", secret="s3cret")
+
+        # attribute access still works
+        assert user.password == "hashed"
+        assert user.secret == "s3cret"
+
+        # asrecord() still includes excluded fields
+        record = user.asrecord()
+        assert record == {
+            "id_user": 1,
+            "username": "alice",
+            "password_hash": "hashed",
+            "secret_key": "s3cret",
+        }
+
+        # fields() still includes excluded fields
+        assert "password" in user.fields()
+        assert "secret" in user.fields()
+
+        # values() still includes excluded fields
+        assert "hashed" in user.values()
+        assert "s3cret" in user.values()
+
+    def test_json_exclude_attribute_set_on_class(self):
+        """The _json_exclude attribute is properly set on decorated classes"""
+        assert getattr(SecureUser, ATTR_JSON_EXCLUDE) == {"password", "secret"}
+        assert getattr(User, ATTR_JSON_EXCLUDE) == set()
+
+    def test_empty_exclude_returns_all(self):
+        """Passing an empty list to exclude returns all fields (no class-level exclude)"""
+        user = User(id=1, name="john")
+        result = user.asdict(exclude=[])
+        assert result == {"id": 1, "name": "john"}

--- a/tox.ini
+++ b/tox.ini
@@ -42,13 +42,36 @@ healthcheck_interval = 1
 healthcheck_start_period = 1
 host_var = PGHOST
 
+[docker:clickhouse_db]
+image=clickhouse/clickhouse-server:25.8
+environment =
+    CLICKHOUSE_USER=some_user
+    CLICKHOUSE_PASSWORD=somePassword
+    CLICKHOUSE_DB=testdb
+    CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
+
+expose =
+    CLICKHOUSE_PORT=8123/tcp
+
+healthcheck_cmd = wget --no-verbose --tries=1 --spider http://localhost:8123/ping || exit 1
+healthcheck_timeout = 1
+healthcheck_retries = 30
+healthcheck_interval = 1
+healthcheck_start_period = 5
+host_var = CLICKHOUSE_HOST
+
 
 [testenv:py{310,311,312,313,314}]
-docker = pg_db
+docker =
+    pg_db
+    clickhouse_db
 
 setenv =
     POSTGRES_USER=some_user
     POSTGRES_PASSWORD=somePassword
     POSTGRES_DB=testdb
+    CLICKHOUSE_USER=some_user
+    CLICKHOUSE_PASSWORD=somePassword
+    CLICKHOUSE_DB=testdb
 
 


### PR DESCRIPTION
## Summary by Sourcery

Add ClickHouse backend support, enhance JSON querying APIs and docs, and harden SQL identifier quoting across dialects.

New Features:
- Introduce ClickHouseSqlDialect with ClickHouse-specific placeholders, JSON functions, and mutation semantics.
- Add ClickHouseConnection, repository, manager, and migration manager implementations, plus CLI integration for ClickHouse migrations.
- Extend Select with JSON helper methods (json_field, json_extract, json_where) and add JsonField/PgJsonField abstractions for dialect-aware JSON operations.
- Support json_exclude on fieldmapped records and per-call exclude parameter on asdict() for safer serialization.

Bug Fixes:
- Fix SQL identifier quoting across dialects by escaping embedded double-quotes, preventing identifier injection in DDL-related operations.
- Correct select builder and pagination/order-by examples in documentation to reflect actual query output.

Enhancements:
- Add identifier-escaping tests and ClickHouse-specific SQL builder tests for update/delete, dialect behavior, and repository operations.
- Refine migration and manager interfaces to handle ClickHouse metadata, databases, and mutation-style DDL/DML.
- Clarify profiler usage with connection pools and improve various docs for JSON operations, query building, and supported dialects.

Build:
- Update tox configuration to provision a ClickHouse Docker service alongside PostgreSQL for integration tests.

Documentation:
- Document ClickHouse usage, connection parameters, manager support, and migration engine options.
- Add comprehensive guides and API references for JSON operations (JsonField, PgJsonField, Select JSON helpers).
- Update high-level project docs (README, CLAUDE, mkdocs navigation, install, connection, select, dialect, manager, migrations, with, update, building_queries) to reflect ClickHouse support and corrected examples.

Tests:
- Add ClickHouse integration tests for connection, manager, repository, migrations, and dialect-specific SQL builders.
- Extend mapper and dialect test suites to cover json_exclude behavior and secure identifier escaping across dialects.
- Introduce ClickHouse-specific pytest fixtures and tox-docker configuration for running backend tests against a real ClickHouse instance.

Chores:
- Update CHANGELOG with 2.2.0 and 2.3.0 entries describing ClickHouse support, JSON serialization controls, and security hardening.
- Add FieldRecord and UserRecord docs to mkdocs navigation.