### PR TITLE
Development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.0]
+
+### Added
+- `MySqlSqlDialect` — MySQL SQL dialect for the query builder, with backtick identifier quoting, `%s` placeholders, JSON support (`JSON_EXTRACT`, `JSON_UNQUOTE`, `JSON_CONTAINS`, `JSON_CONTAINS_PATH`), no `INSERT...RETURNING`, no `ILIKE` (uses `UPPER()` fallback in DbGrid)
+
 ## [2.3.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # Changelog
 
-## [2.4.0]
-
-### Added
-- `MySqlSqlDialect` — MySQL SQL dialect for the query builder, with backtick identifier quoting, `%s` placeholders, JSON support (`JSON_EXTRACT`, `JSON_UNQUOTE`, `JSON_CONTAINS`, `JSON_CONTAINS_PATH`), no `INSERT...RETURNING`, no `ILIKE` (uses `UPPER()` fallback in DbGrid)
-
 ## [2.3.0]
 
 ### Added
@@ -17,6 +12,7 @@
   - `ClickHouseSqlDialect` — dialect with ClickHouse-specific placeholders, JSON functions, and no `INSERT...RETURNING`
 - ClickHouse integration tests using `tox-docker` with `clickhouse/clickhouse-server:25.8`
 - `clickhouse-connect>=0.7.0` added to dev dependencies
+- `MySqlSqlDialect` — MySQL SQL dialect for the query builder, with backtick identifier quoting, `%s` placeholders, JSON support (`JSON_EXTRACT`, `JSON_UNQUOTE`, `JSON_CONTAINS`, `JSON_CONTAINS_PATH`), no `INSERT...RETURNING`, no `ILIKE` (uses `UPPER()` fallback in DbGrid)
 
 ### Changed
 - Updated `tox.ini` to include ClickHouse docker service alongside PostgreSQL

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 SQL database abstraction layer for Python. **Not an ORM** — follows a schema-first approach where the database structure is managed independently via SQL DDL.
 
-Supports **PostgreSQL** (psycopg2), **SQLite3**, and **ClickHouse** (clickhouse-connect).
+Supports **PostgreSQL** (psycopg2), **SQLite3**, and **ClickHouse** (clickhouse-connect). **MySQL** is supported at the SQL query builder level via `MySqlSqlDialect`.
 
 ## Quick Start
 
@@ -77,6 +77,7 @@ from rick_db.sql import Select, Insert, Update, Delete, Literal, PgSqlDialect
 
 dialect = PgSqlDialect()   # uses %s placeholders
 # or Sqlite3SqlDialect()   # uses ? placeholders
+# or MySqlSqlDialect()     # uses %s placeholders, backtick quoting
 ```
 
 ### Select

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ and a Repository pattern implementation. It is **not** an ORM, and it's not mean
 - Object Mapper;
 - Fluent Sql Query builder;
 - High level connectors for PostgreSQL, SQLite3, ClickHouse;
+- SQL query builder dialect for MySQL;
 - Pluggable SQL query profiler; 
 - Simple migration manager for SQL files;
 

--- a/docs/building_queries.md
+++ b/docs/building_queries.md
@@ -5,8 +5,10 @@ cross-schema operations), JOIN support, JSON operations, and recognizes [Record]
 identification.
 
 The query builder provides SQL generation using a fluent interface, suitable for most cases. Different database support
-is handled via dialect objects (extending from SqlDialect). The query builder itself will only generate a SQL string
-and a parameter value list; it is up to the developer to use the generated SQL in the appropriate database context.
+is handled via dialect objects (extending from SqlDialect): `PgSqlDialect` for PostgreSQL, `Sqlite3SqlDialect` for
+SQLite, `ClickHouseSqlDialect` for ClickHouse, and `MySqlSqlDialect` for MySQL. The query builder itself will only
+generate a SQL string and a parameter value list; it is up to the developer to use the generated SQL in the appropriate
+database context.
 
 ## Select
 

--- a/docs/classes/sqldialect.md
+++ b/docs/classes/sqldialect.md
@@ -7,6 +7,7 @@ Available dialect implementations:
 - **PgSqlDialect** — PostgreSQL dialect (`%s` placeholders, `INSERT...RETURNING`, `ILIKE`, JSONB operators)
 - **Sqlite3SqlDialect** — SQLite3 dialect (`?` placeholders, no `ILIKE`, no JSON)
 - **ClickHouseSqlDialect** — ClickHouse dialect (`%s` placeholders, no `INSERT...RETURNING`, `ILIKE`, JSON functions via `JSONExtractString`/`JSONHas`/`JSON_EXISTS`)
+- **MySqlSqlDialect** — MySQL dialect (`%s` placeholders, backtick identifier quoting, no `INSERT...RETURNING`, no `ILIKE`, JSON functions via `JSON_EXTRACT`/`JSON_UNQUOTE`/`JSON_CONTAINS`/`JSON_CONTAINS_PATH`)
 
 ### SqlDialect.**table(table_name, alias=None, schema=None)**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ and a Repository pattern implementation.
 - Fluent SQL Query builder with schema support
 - Comprehensive JSON operations support
 - High level connectors for PostgreSQL, SQLite, ClickHouse
+- SQL query builder dialect for MySQL
 - Pluggable SQL query profiler
 - Grid helper
 - Migration Manager

--- a/docs/json_operations.md
+++ b/docs/json_operations.md
@@ -307,15 +307,16 @@ print(values)
 
 ## Dialect support
 
-| Feature | PostgreSQL | SQLite | Generic |
-|---|---|---|---|
-| `extract()` | `->>` operator | Not built-in | `JSON_EXTRACT()` |
-| `extract_text()` | `->>` operator | Not built-in | `JSON_EXTRACT()` |
-| `extract_object()` | `->` operator | N/A | N/A |
-| `path_query()` | `@?` operator | N/A | N/A |
-| `contains()` | `@>` operator | Not built-in | `JSON_CONTAINS()` |
-| `has_path()` | `??` operator | Not built-in | `JSON_CONTAINS_PATH()` |
-| `as_jsonb()` / `as_json()` | Type casting | N/A | N/A |
+| Feature | PostgreSQL | MySQL | SQLite | Generic |
+|---|---|---|---|---|
+| `extract()` | `->>` operator | `JSON_EXTRACT()` | Not built-in | `JSON_EXTRACT()` |
+| `extract_text()` | `->>` operator | `JSON_UNQUOTE(JSON_EXTRACT())` | Not built-in | `JSON_EXTRACT()` |
+| `extract_object()` | `->` operator | N/A | N/A | N/A |
+| `path_query()` | `@?` operator | N/A | N/A | N/A |
+| `contains()` | `@>` operator | `JSON_CONTAINS()` | Not built-in | `JSON_CONTAINS()` |
+| `has_path()` | `??` operator | `JSON_CONTAINS_PATH()` | Not built-in | `JSON_CONTAINS_PATH()` |
+| `as_jsonb()` / `as_json()` | Type casting | N/A | N/A | N/A |
 
-PostgreSQL has native JSON support enabled by default in `PgSqlDialect`. The `Sqlite3SqlDialect` does not currently
-enable `json_support`, so JSON operations will fall back to generic syntax if used with a `JsonField` without a dialect.
+PostgreSQL has native JSON support enabled by default in `PgSqlDialect`. MySQL has JSON support enabled by default
+in `MySqlSqlDialect`, using MySQL 5.7+ JSON functions. The `Sqlite3SqlDialect` does not currently enable `json_support`,
+so JSON operations will fall back to generic syntax if used with a `JsonField` without a dialect.

--- a/rick_db/sql/__init__.py
+++ b/rick_db/sql/__init__.py
@@ -1,5 +1,5 @@
 from .common import SqlError, SqlStatement, Sql, Literal, L, JsonField, PgJsonField
-from .dialect import SqlDialect, Sqlite3SqlDialect, PgSqlDialect, DefaultSqlDialect, ClickHouseSqlDialect
+from .dialect import SqlDialect, Sqlite3SqlDialect, PgSqlDialect, DefaultSqlDialect, ClickHouseSqlDialect, MySqlSqlDialect
 from .select import Select
 from .insert import Insert
 from .delete import Delete
@@ -19,6 +19,7 @@ __all__ = [
     "PgSqlDialect",
     "DefaultSqlDialect",
     "ClickHouseSqlDialect",
+    "MySqlSqlDialect",
     "Select",
     "Insert",
     "Delete",

--- a/rick_db/sql/dialect.py
+++ b/rick_db/sql/dialect.py
@@ -499,6 +499,32 @@ class PgSqlDialect(SqlDialect):
         return expr
 
 
+class MySqlSqlDialect(SqlDialect):
+    """
+    MySQL SqlDialect implementation
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.placeholder = "%s"
+        self.insert_returning = False
+        self.ilike = False
+        self.json_support = True
+
+        # Override only _json_extract_text for unquoted text extraction
+        self._json_extract_text = "JSON_UNQUOTE(JSON_EXTRACT({field}, {path}))"
+
+    def _qi(self, identifier):
+        """
+        Quote a SQL identifier with backticks, escaping embedded backticks by doubling.
+
+        :param identifier: identifier name (table, field, schema, database)
+        :return: quoted identifier string, e.g. `my_table`
+        """
+        escaped = identifier.replace('`', '``')
+        return '`{}`'.format(escaped)
+
+
 class ClickHouseSqlDialect(SqlDialect):
     """
     ClickHouse SqlDialect implementation

--- a/rick_db/version.py
+++ b/rick_db/version.py
@@ -1,4 +1,4 @@
-RICK_DB_VERSION = ["2", "1", "0"]
+RICK_DB_VERSION = ["2", "3", "0"]
 
 
 def get_version():

--- a/tests/sql/test_dialect.py
+++ b/tests/sql/test_dialect.py
@@ -1,6 +1,6 @@
 import pytest
 
-from rick_db.sql import PgSqlDialect, SqlDialect
+from rick_db.sql import PgSqlDialect, SqlDialect, MySqlSqlDialect
 from rick_db.sql.common import Literal
 
 TABLE_NAME = "test_table"
@@ -159,3 +159,150 @@ class TestSqlDialect:
     )
     def test_pgsqldialect_field(self, field, field_alias, table, schema, result):
         assert PgSqlDialect().field(field, field_alias, table, schema) == result
+
+
+def mysql_dialect_table():
+    return [
+        ["name", None, None, "`name`"],
+        ["name", "alias", None, "`name` AS `alias`"],
+        ["name", "alias", "schema", "`schema`.`name` AS `alias`"],
+        ["name", None, "schema", "`schema`.`name`"],
+    ]
+
+
+def mysql_dialect_database():
+    return [
+        ["name", None, "`name`"],
+        ["name", "alias", "`name` AS `alias`"],
+    ]
+
+
+def mysql_dialect_field():
+    return [
+        # simple fields
+        ["field", None, None, None, "`field`"],
+        ["field", "alias", None, None, "`field` AS `alias`"],
+        ["field", "alias", "table", None, "`table`.`field` AS `alias`"],
+        ["field", "alias", "table", "schema", "`schema`.`table`.`field` AS `alias`"],
+        # field literals
+        [Literal("TOP(field)"), None, None, None, "TOP(field)"],
+        [Literal("TOP(field)"), "alias", None, None, "TOP(field) AS `alias`"],
+        [
+            Literal("TOP(field)"),
+            "alias",
+            "table",
+            "schema",
+            "TOP(field) AS `alias`",
+        ],
+        # field alias and casting
+        ["field", ["text"], None, None, "CAST(`field` AS text)"],
+        ["field", ["text"], "table", None, "CAST(`table`.`field` AS text)"],
+        [
+            "field",
+            ["text"],
+            "table",
+            "schema",
+            "CAST(`schema`.`table`.`field` AS text)",
+        ],
+        ["field", ["text", "alias"], None, None, "CAST(`field` AS text) AS `alias`"],
+        [
+            "field",
+            ["text", "alias"],
+            "table",
+            None,
+            "CAST(`table`.`field` AS text) AS `alias`",
+        ],
+        [
+            "field",
+            ["text", "alias"],
+            "table",
+            "schema",
+            "CAST(`schema`.`table`.`field` AS text) AS `alias`",
+        ],
+    ]
+
+
+class TestMySqlDialect:
+    def test_import_from_sql_package(self):
+        from rick_db.sql import MySqlSqlDialect as Imported
+
+        d = Imported()
+        assert isinstance(d, Imported)
+        assert isinstance(d, SqlDialect)
+
+    @pytest.mark.parametrize("table_name, alias, schema, result", mysql_dialect_table())
+    def test_mysqldialect_table(self, table_name, alias, schema, result):
+        assert MySqlSqlDialect().table(table_name, alias, schema) == result
+
+    @pytest.mark.parametrize("db_name, alias, result", mysql_dialect_database())
+    def test_mysqldialect_database(self, db_name, alias, result):
+        assert MySqlSqlDialect().database(db_name, alias) == result
+
+    @pytest.mark.parametrize(
+        "field, field_alias, table, schema, result", mysql_dialect_field()
+    )
+    def test_mysqldialect_field(self, field, field_alias, table, schema, result):
+        assert MySqlSqlDialect().field(field, field_alias, table, schema) == result
+
+    def test_identifier_escaping_backtick(self):
+        d = MySqlSqlDialect()
+        assert d.table("tab`le") == "`tab``le`"
+        assert d.table("safe") == "`safe`"
+        assert d.table("t", alias="a`lias") == "`t` AS `a``lias`"
+        assert d.table("t", schema="s`ch") == "`s``ch`.`t`"
+
+    def test_identifier_escaping_field(self):
+        d = MySqlSqlDialect()
+        assert d.field("fi`eld") == "`fi``eld`"
+        assert d.field("f", field_alias="a`l") == "`f` AS `a``l`"
+        assert d.field("f", table="t`bl") == "`t``bl`.`f`"
+
+    def test_identifier_escaping_database(self):
+        d = MySqlSqlDialect()
+        assert d.database("db`name") == "`db``name`"
+        assert d.database("db", alias="a`l") == "`db` AS `a``l`"
+
+    def test_dialect_properties(self):
+        d = MySqlSqlDialect()
+        assert d.placeholder == "%s"
+        assert d.insert_returning is False
+        assert d.ilike is False
+        assert d.json_support is True
+
+    def test_json_extract(self):
+        d = MySqlSqlDialect()
+        assert d.json_extract("data", "$.name") == "JSON_EXTRACT(`data`, '$.name')"
+        assert (
+            d.json_extract("data", "$.name", "username")
+            == "JSON_EXTRACT(`data`, '$.name') AS `username`"
+        )
+
+    def test_json_extract_text(self):
+        d = MySqlSqlDialect()
+        assert (
+            d.json_extract_text("data", "$.name")
+            == "JSON_UNQUOTE(JSON_EXTRACT(`data`, '$.name'))"
+        )
+        assert (
+            d.json_extract_text("data", "$.name", "username")
+            == "JSON_UNQUOTE(JSON_EXTRACT(`data`, '$.name')) AS `username`"
+        )
+
+    def test_json_contains(self):
+        d = MySqlSqlDialect()
+        assert d.json_contains("data", "value") == "JSON_CONTAINS(`data`, %s)"
+        assert (
+            d.json_contains("data", "value", "has_val")
+            == "JSON_CONTAINS(`data`, %s) AS `has_val`"
+        )
+
+    def test_json_contains_path(self):
+        d = MySqlSqlDialect()
+        assert (
+            d.json_contains_path("data", "$.name")
+            == "JSON_CONTAINS_PATH(`data`, 'one', '$.name')"
+        )
+        assert (
+            d.json_contains_path("data", "$.name", "has_name")
+            == "JSON_CONTAINS_PATH(`data`, 'one', '$.name') AS `has_name`"
+        )


### PR DESCRIPTION
## Summary by Sourcery

Add a MySQL-specific SQL dialect with JSON support and backtick quoting, and document its availability in the query builder and JSON features.

New Features:
- Introduce MySqlSqlDialect implementing MySQL-specific identifier quoting, placeholders, and JSON function support for the SQL query builder.

Enhancements:
- Expose MySqlSqlDialect from the sql package and describe it alongside existing dialects in the dialect and query builder documentation.
- Update JSON operations documentation to detail MySQL-specific behavior and function mappings.

Documentation:
- Document MySQL dialect support across README, index, class reference, JSON operations guide, and CLAUDE usage notes.

Tests:
- Add comprehensive unit tests for MySqlSqlDialect covering table/field/database formatting, identifier escaping, and JSON helper methods.

Chores:
- Bump library version to 2.3.0 and update the changelog to record the addition of the MySQL SQL dialect.