### PR TITLE
Fix wrong version 2.3.0 -> 2.2.0, move MySQL dialect changelog to correct section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
   - `ClickHouseSqlDialect` — dialect with ClickHouse-specific placeholders, JSON functions, and no `INSERT...RETURNING`
 - ClickHouse integration tests using `tox-docker` with `clickhouse/clickhouse-server:25.8`
 - `clickhouse-connect>=0.7.0` added to dev dependencies
-- `MySqlSqlDialect` — MySQL SQL dialect for the query builder, with backtick identifier quoting, `%s` placeholders, JSON support (`JSON_EXTRACT`, `JSON_UNQUOTE`, `JSON_CONTAINS`, `JSON_CONTAINS_PATH`), no `INSERT...RETURNING`, no `ILIKE` (uses `UPPER()` fallback in DbGrid)
 
 ### Changed
 - Updated `tox.ini` to include ClickHouse docker service alongside PostgreSQL
@@ -23,6 +22,7 @@
 ## [2.2.0]
 
 ### Added
+- `MySqlSqlDialect` — MySQL SQL dialect for the query builder, with backtick identifier quoting, `%s` placeholders, JSON support (`JSON_EXTRACT`, `JSON_UNQUOTE`, `JSON_CONTAINS`, `JSON_CONTAINS_PATH`), no `INSERT...RETURNING`, no `ILIKE` (uses `UPPER()` fallback in DbGrid)
 - `json_exclude` parameter on `@fieldmapper` decorator to exclude fields from `asdict()` serialization at the class level
 - `exclude` parameter on `asdict()` for per-call field exclusion, merged with class-level defaults
 - Excluded fields remain accessible via attribute access, `asrecord()`, `fields()`, and `values()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [2.3.0]
+## [2.2.0]
 
 ### Added
 - ClickHouse backend support via `clickhouse-connect` HTTP client
@@ -12,20 +12,16 @@
   - `ClickHouseSqlDialect` — dialect with ClickHouse-specific placeholders, JSON functions, and no `INSERT...RETURNING`
 - ClickHouse integration tests using `tox-docker` with `clickhouse/clickhouse-server:25.8`
 - `clickhouse-connect>=0.7.0` added to dev dependencies
+- `MySqlSqlDialect` — MySQL SQL dialect for the query builder, with backtick identifier quoting, `%s` placeholders, JSON support (`JSON_EXTRACT`, `JSON_UNQUOTE`, `JSON_CONTAINS`, `JSON_CONTAINS_PATH`), no `INSERT...RETURNING`, no `ILIKE` (uses `UPPER()` fallback in DbGrid)
+- `json_exclude` parameter on `@fieldmapper` decorator to exclude fields from `asdict()` serialization at the class level
+- `exclude` parameter on `asdict()` for per-call field exclusion, merged with class-level defaults
+- Excluded fields remain accessible via attribute access, `asrecord()`, `fields()`, and `values()`
 
 ### Changed
 - Updated `tox.ini` to include ClickHouse docker service alongside PostgreSQL
 
 ### Security
 - **sql/dialect.py**: Fixed SQL identifier quoting across all dialects (PostgreSQL, SQLite, ClickHouse) to escape embedded double-quotes by doubling them (SQL standard). Previously, `dialect.table()`, `dialect.field()`, and `dialect.database()` wrapped names in double-quotes without escaping, allowing identifier injection in Manager DDL methods (`create_database`, `drop_database`, `drop_table`, `drop_view`)
-
-## [2.2.0]
-
-### Added
-- `MySqlSqlDialect` — MySQL SQL dialect for the query builder, with backtick identifier quoting, `%s` placeholders, JSON support (`JSON_EXTRACT`, `JSON_UNQUOTE`, `JSON_CONTAINS`, `JSON_CONTAINS_PATH`), no `INSERT...RETURNING`, no `ILIKE` (uses `UPPER()` fallback in DbGrid)
-- `json_exclude` parameter on `@fieldmapper` decorator to exclude fields from `asdict()` serialization at the class level
-- `exclude` parameter on `asdict()` for per-call field exclusion, merged with class-level defaults
-- Excluded fields remain accessible via attribute access, `asrecord()`, `fields()`, and `values()`
 
 ## [2.1.0]
 

--- a/rick_db/version.py
+++ b/rick_db/version.py
@@ -1,4 +1,4 @@
-RICK_DB_VERSION = ["2", "3", "0"]
+RICK_DB_VERSION = ["2", "2", "0"]
 
 
 def get_version():


### PR DESCRIPTION
## Summary by Sourcery

Align version metadata with the 2.2.0 release and correct the changelog entry for the MySQL SQL dialect.

Documentation:
- Move the MySQL dialect changelog entry into the correct 2.2.0 'Added' section to accurately reflect when it was introduced.

Chores:
- Update the library version constant from 2.3.0 to 2.2.0 to match the current release.