### PR TITLE
Development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2.2.1]
+
+### Added
+- `Fn` helper class for common SQL functions in the query builder, returning `Literal` instances for use in column definitions
+  - Aggregate: `count`, `sum`, `avg`, `min`, `max`
+  - Math: `abs`, `ceil`, `floor`, `round`, `power`, `sqrt`, `mod`, `sign`, `trunc`
+  - General: `coalesce`, `cast`
+- `WHERE IN` / `WHERE NOT IN` support for `Select`, `Update`, and `Delete` query builders with parameterized list/tuple values
+- `cls` parameter on `Repository.fetch_one()`, `fetch_by_field()`, `fetch_where()`, `fetch_all()`, and `fetch_all_ordered()` to override the default record class
+- Dataclass and plain class support in `Cursor.fetchone()`, `fetchall()`, and `exec()` — classes without `fromrecord` are instantiated via `cls(**dict(row))`
+
 ## [2.2.0]
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,17 @@ repo.update(user)
 
 # Delete
 repo.delete_pk(user_id)
+
+# Fetch with a dataclass instead of fieldmapper record
+from dataclasses import dataclass
+
+@dataclass
+class UserInfo:
+    name: str
+    email: str
+
+users = repo.fetch_where([("active", "=", True)], cols=["name", "email"], cls=UserInfo)
+user = repo.fetch_one(repo.select(cols=["name", "email"]), cls=UserInfo)
 ```
 
 ## SQL Query Builder
@@ -89,6 +100,10 @@ Select(dialect).from_(User, [User.id, User.name]).assemble()
 
 # WHERE
 Select(dialect).from_(User).where(User.name, "=", "Alice").assemble()
+
+# WHERE IN / NOT IN (parameterized)
+Select(dialect).from_(User).where(User.id, "in", [1, 2, 3]).assemble()
+Select(dialect).from_(User).where(User.id, "not in", [4, 5]).assemble()
 
 # JOIN
 Select(dialect).from_(User).join(Order, User.id, Order, Order.user_id).assemble()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ user = repo.fetch_one(repo.select(cols=["name", "email"]), cls=UserInfo)
 Fluent builders for SELECT, INSERT, UPDATE, DELETE. All builders require a dialect and produce `(sql, values)` tuples via `.assemble()`.
 
 ```python
-from rick_db.sql import Select, Insert, Update, Delete, Literal, PgSqlDialect
+from rick_db.sql import Select, Insert, Update, Delete, Literal, Fn, PgSqlDialect
 
 dialect = PgSqlDialect()   # uses %s placeholders
 # or Sqlite3SqlDialect()   # uses ? placeholders
@@ -108,8 +108,14 @@ Select(dialect).from_(User).where(User.id, "not in", [4, 5]).assemble()
 # JOIN
 Select(dialect).from_(User).join(Order, User.id, Order, Order.user_id).assemble()
 
-# Aggregation
-Select(dialect).from_(User, {Literal("COUNT(*)"): "total"}).group(User.active).assemble()
+# Aggregation with Fn helpers
+Select(dialect).from_(User, {Fn.count(): "total"}).group(User.active).assemble()
+Select(dialect).from_(User, {
+    User.name: None,
+    Fn.count(): "cnt",
+    Fn.sum("amount"): "total",
+    Fn.round(Fn.avg("price"), 2): "avg_price",
+}).group(User.name).assemble()
 
 # Pagination
 Select(dialect).from_(User).order(User.name).limit(10, offset=20).assemble()

--- a/docs/building_queries.md
+++ b/docs/building_queries.md
@@ -214,6 +214,26 @@ qry, values = (
 print(qry)
 ```
 
+**WHERE IN / NOT IN** with a list of values generates properly parameterized queries:
+
+```python
+from rick_db.sql import Select, PgSqlDialect
+
+# WHERE IN with a list
+qry, values = Select(PgSqlDialect()).from_("table").where("id", "IN", [1, 2, 3]).assemble()
+# output: SELECT "table".* FROM "table" WHERE ("id" IN (%s, %s, %s))
+# values: [1, 2, 3]
+print(qry)
+
+# WHERE NOT IN with a list
+qry, values = Select(PgSqlDialect()).from_("table").where("status", "NOT IN", ["inactive", "deleted"]).assemble()
+# output: SELECT "table".* FROM "table" WHERE ("status" NOT IN (%s, %s))
+# values: ['inactive', 'deleted']
+print(qry)
+```
+
+Tuples are also accepted as value lists. An empty list will raise `SqlError`.
+
 It is also possible to use subselects:
 
 ```python
@@ -351,6 +371,16 @@ qry = (
 )
 # output: ('UPDATE "table" SET "field"=%s WHERE "id" = %s AND "name" ILIKE %s', ['value', 7, 'john%'])
 print(qry.assemble())
+
+# UPDATE WHERE... IN with a list
+qry = (
+    Update(PgSqlDialect())
+    .table("table")
+    .values({"field": "value"})
+    .where("id", "IN", [1, 2, 3])
+)
+# output: ('UPDATE "table" SET "field"=%s WHERE "id" IN (%s, %s, %s)', ['value', 1, 2, 3])
+print(qry.assemble())
 ```
 
 ## Delete
@@ -379,6 +409,11 @@ qry = (
     .where("name", "ILIKE", "john%")
 )
 # output: ('DELETE FROM "table" WHERE "id" = %s AND "name" ILIKE %s', [7, 'john%'])
+print(qry.assemble())
+
+# DELETE WHERE... IN with a list
+qry = Delete(PgSqlDialect()).from_("table").where("id", "IN", [1, 2, 3])
+# output: ('DELETE FROM "table" WHERE "id" IN (%s, %s, %s)', [1, 2, 3])
 print(qry.assemble())
 ```
 

--- a/docs/building_queries.md
+++ b/docs/building_queries.md
@@ -268,6 +268,74 @@ qry, _ = Select(PgSqlDialect()).from_('table', {Literal('COUNT(*)'):'total'}).as
 print(qry)
 ```
 
+## SQL Functions
+
+The [Fn](classes/fn.md) class provides helpers for common SQL functions. Each method returns a
+[Literal](classes/literal.md), so they work anywhere a Literal is accepted. Use dict-style column definitions
+to alias the results:
+
+```python
+from rick_db.sql import Select, Fn, PgSqlDialect
+
+# Single aggregate with alias
+qry, _ = Select(PgSqlDialect()).from_("orders", {Fn.count(): "total"}).assemble()
+# output: SELECT COUNT(*) AS "total" FROM "orders"
+print(qry)
+
+# Multiple columns: regular fields and aggregates together
+qry, _ = (
+    Select(PgSqlDialect())
+    .from_("orders", {
+        "category": None,
+        Fn.count(): "order_count",
+        Fn.sum("amount"): "total_amount",
+        Fn.avg("amount"): "avg_amount",
+    })
+    .group("category")
+    .assemble()
+)
+# output: SELECT "category",COUNT(*) AS "order_count",SUM(amount) AS "total_amount",AVG(amount) AS "avg_amount" FROM "orders" GROUP BY "category"
+print(qry)
+
+# Nested functions
+qry, _ = (
+    Select(PgSqlDialect())
+    .from_("orders", {
+        "category": None,
+        Fn.round(Fn.avg("amount"), 2): "avg_rounded",
+    })
+    .group("category")
+    .assemble()
+)
+# output: SELECT "category",ROUND(AVG(amount), 2) AS "avg_rounded" FROM "orders" GROUP BY "category"
+print(qry)
+
+# Multiple aggregates with HAVING
+qry, _ = (
+    Select(PgSqlDialect())
+    .from_("orders", {
+        "category": None,
+        Fn.count(): "cnt",
+        Fn.min("price"): "cheapest",
+        Fn.max("price"): "priciest",
+        Fn.sum("amount"): "total",
+    })
+    .group("category")
+    .having(Fn.count(), ">", 5)
+    .assemble()
+)
+# output: SELECT "category",COUNT(*) AS "cnt",MIN(price) AS "cheapest",MAX(price) AS "priciest",SUM(amount) AS "total" FROM "orders" GROUP BY "category" HAVING (COUNT(*) > %s)
+print(qry)
+```
+
+Available functions:
+
+- **Aggregate**: `count`, `sum`, `avg`, `min`, `max`
+- **Math**: `abs`, `ceil`, `floor`, `round`, `power`, `sqrt`, `mod`, `sign`, `trunc`
+- **General**: `coalesce`, `cast`
+
+See [Fn class documentation](classes/fn.md) for full reference.
+
 ## Insert
 
 [Insert](classes/insert.md) objects can be used to generate SQL **INSERT** statements, with optional **RETURNING** clause,

--- a/docs/classes/delete.md
+++ b/docs/classes/delete.md
@@ -50,6 +50,16 @@ qry = (
 )
 # output: ('DELETE FROM "table" WHERE "id" = %s AND "name" ILIKE %s', [7, 'john%'])
 print(qry.assemble())
+
+# DELETE WHERE... IN with a list of values
+qry = Delete(PgSqlDialect()).from_("table").where("id", "IN", [1, 2, 3])
+# output: ('DELETE FROM "table" WHERE "id" IN (%s, %s, %s)', [1, 2, 3])
+print(qry.assemble())
+
+# DELETE WHERE... NOT IN
+qry = Delete(PgSqlDialect()).from_("table").where("status", "NOT IN", ["archived", "deleted"])
+# output: ('DELETE FROM "table" WHERE "status" NOT IN (%s, %s)', ['archived', 'deleted'])
+print(qry.assemble())
 ```
 
 

--- a/docs/classes/fn.md
+++ b/docs/classes/fn.md
@@ -1,0 +1,169 @@
+# Class rick_db.sql.**Fn**
+
+SQL function helpers that return [Literal](literal.md) instances. Designed to be used with dict-style column
+definitions for aliasing.
+
+All methods are static and return a `Literal`, so they can be used anywhere a `Literal` is accepted: column lists,
+`having()` clauses, nested inside other `Fn` calls, etc.
+
+## Aggregate Functions
+
+### Fn.**count(field="*")**
+
+Returns `Literal("COUNT(field)")`.
+
+```python
+Fn.count()          # COUNT(*)
+Fn.count("id")      # COUNT(id)
+```
+
+### Fn.**sum(field)**
+
+Returns `Literal("SUM(field)")`.
+
+### Fn.**avg(field)**
+
+Returns `Literal("AVG(field)")`.
+
+### Fn.**min(field)**
+
+Returns `Literal("MIN(field)")`.
+
+### Fn.**max(field)**
+
+Returns `Literal("MAX(field)")`.
+
+## Math Functions
+
+### Fn.**abs(field)**
+
+Returns `Literal("ABS(field)")`.
+
+### Fn.**ceil(field)**
+
+Returns `Literal("CEIL(field)")`.
+
+### Fn.**floor(field)**
+
+Returns `Literal("FLOOR(field)")`.
+
+### Fn.**round(field, decimals=None)**
+
+Returns `Literal("ROUND(field)")` or `Literal("ROUND(field, decimals)")` if *decimals* is specified.
+
+```python
+Fn.round("price")       # ROUND(price)
+Fn.round("price", 2)    # ROUND(price, 2)
+```
+
+### Fn.**power(field, exponent)**
+
+Returns `Literal("POWER(field, exponent)")`.
+
+### Fn.**sqrt(field)**
+
+Returns `Literal("SQRT(field)")`.
+
+### Fn.**mod(field, divisor)**
+
+Returns `Literal("MOD(field, divisor)")`.
+
+### Fn.**sign(field)**
+
+Returns `Literal("SIGN(field)")`.
+
+### Fn.**trunc(field, decimals=None)**
+
+Returns `Literal("TRUNC(field)")` or `Literal("TRUNC(field, decimals)")` if *decimals* is specified.
+
+```python
+Fn.trunc("price")       # TRUNC(price)
+Fn.trunc("price", 1)    # TRUNC(price, 1)
+```
+
+## General Functions
+
+### Fn.**coalesce(*fields)**
+
+Returns `Literal("COALESCE(field1, field2, ...)")`.
+
+```python
+Fn.coalesce("nickname", "name", "'unknown'")   # COALESCE(nickname, name, 'unknown')
+```
+
+### Fn.**cast(field, type_name)**
+
+Returns `Literal("CAST(field AS type_name)")`.
+
+```python
+Fn.cast("price", "integer")   # CAST(price AS integer)
+```
+
+## Usage
+
+`Fn` helpers return `Literal` objects, so they are used with dict-style column definitions where the key is the
+expression and the value is the alias (or `None` for no alias):
+
+```python
+from rick_db.sql import Select, Fn, PgSqlDialect
+
+dialect = PgSqlDialect()
+
+# Single aggregate
+qry, _ = Select(dialect).from_("orders", {Fn.count(): "total"}).assemble()
+# output: SELECT COUNT(*) AS "total" FROM "orders"
+
+# Multiple columns with aggregates
+qry, _ = (
+    Select(dialect)
+    .from_("orders", {
+        "category": None,
+        Fn.count(): "order_count",
+        Fn.sum("amount"): "total_amount",
+        Fn.avg("amount"): "avg_amount",
+    })
+    .group("category")
+    .assemble()
+)
+# output: SELECT "category",COUNT(*) AS "order_count",SUM(amount) AS "total_amount",AVG(amount) AS "avg_amount" FROM "orders" GROUP BY "category"
+
+# Nested functions
+qry, _ = (
+    Select(dialect)
+    .from_("orders", {
+        "category": None,
+        Fn.round(Fn.avg("amount"), 2): "avg_rounded",
+    })
+    .group("category")
+    .assemble()
+)
+# output: SELECT "category",ROUND(AVG(amount), 2) AS "avg_rounded" FROM "orders" GROUP BY "category"
+
+# With HAVING
+qry, _ = (
+    Select(dialect)
+    .from_("orders", {
+        "category": None,
+        Fn.sum("amount"): "total",
+    })
+    .group("category")
+    .having(Fn.sum("amount"), ">", 1000)
+    .assemble()
+)
+# output: SELECT "category",SUM(amount) AS "total" FROM "orders" GROUP BY "category" HAVING (SUM(amount) > %s)
+
+# With fieldmapper Record classes
+qry, _ = (
+    Select(dialect)
+    .from_(Order, {
+        Order.category: None,
+        Fn.count(): "cnt",
+        Fn.min(Order.price): "cheapest",
+        Fn.max(Order.price): "priciest",
+        Fn.round(Fn.avg(Order.price), 2): "avg_price",
+    })
+    .group(Order.category)
+    .order(Order.category)
+    .assemble()
+)
+```

--- a/docs/classes/repository.md
+++ b/docs/classes/repository.md
@@ -74,15 +74,27 @@ if record is not None:
     print("record 32 exists")
 ```
 
-### Repository.**fetch_one(qry: Select)**
+### Repository.**fetch_one(qry: Select, cls=None)**
 
 Execute the *qry* [Select](select.md) statement and return a single record. If there is no record to return, will return None.
+If a record class is specified in *cls*, this class will be used as record_type instead of the repository definition.
+Supports both `@fieldmapper` classes and plain classes such as dataclasses.
 
 Example:
 ```python
 (...)
 # fetch record if exists, else returns None
 user = repo.fetch_one(repo.select().where('login', '=', 'gandalf@lotr'))
+
+# fetch using a dataclass
+from dataclasses import dataclass
+
+@dataclass
+class UserInfo:
+    name: str
+    email: str
+
+user = repo.fetch_one(repo.select(cols=['name', 'email']).where('login', '=', 'gandalf@lotr'), cls=UserInfo)
 ```
 
 ### Repository.**fetch(qry: Select, cls=None)**
@@ -113,9 +125,11 @@ for r in repo.fetch_raw(repo.select().where('name', 'like', 'gandalf%')):
     print(r['name'])
 ```
 
-### Repository.**fetch_by_field(field, value, cols=None)**
+### Repository.**fetch_by_field(field, value, cols=None, cls=None)**
 
 Fetch a list of rows where field matches a value. An optional list of fields to be returned can be defined with *cols*.
+If a record class is specified in *cls*, this class will be used as record_type instead of the repository definition.
+Supports both `@fieldmapper` classes and plain classes such as dataclasses.
 It returns a record list, or an empty list if no match is found.
 
 Example:
@@ -125,11 +139,13 @@ Example:
 user = repo.fetch_by_field('login', 'gandalf@lotr')
 ```
 
-### Repository.**fetch_where(where_clauses: list, cols=None)**
+### Repository.**fetch_where(where_clauses: list, cols=None, cls=None)**
 
 Fetch a list of rows that match a list of **WHERE** clauses. If more than one clause is present, they are concatenated
-with **AND**.  An optional list of fields to be returned can be defined with *cols*.  It returns a record list, or an 
-empty list if no match is found.
+with **AND**.  An optional list of fields to be returned can be defined with *cols*.
+If a record class is specified in *cls*, this class will be used as record_type instead of the repository definition.
+Supports both `@fieldmapper` classes and plain classes such as dataclasses.
+It returns a record list, or an empty list if no match is found.
 
 A where clause is a list of tuples in the form of *(field, operator, value)*. See the example below for more details.
 
@@ -141,10 +157,11 @@ for r in repo.fetch_where([('name', 'like', 'gandalf%'), ], cols=['name']):
     print(r.name)
 ```
 
-### Repository.**fetch_all()**
+### Repository.**fetch_all(cls=None)**
 
-Fetch all rows; equivalent to a **SELECT * FROM <record_type_table>**. It returns a record list, or an empty list if 
-the table is empty.
+Fetch all rows; equivalent to a **SELECT * FROM <record_type_table>**. It returns a record list, or an empty list if
+the table is empty. If a record class is specified in *cls*, this class will be used as record_type instead of the
+repository definition. Supports both `@fieldmapper` classes and plain classes such as dataclasses.
 
 Example:
 ```python
@@ -154,10 +171,12 @@ for r in repo.fetch_all():
     print(r.name)
 ```
 
-### Repository.**fetch_all_ordered(col_name:str, order=Sql.SQL_ASC)**
+### Repository.**fetch_all_ordered(col_name:str, order=Sql.SQL_ASC, cls=None)**
 
 Fetch all rows ordered by col_name and order direction; equivalent to a **SELECT * FROM <record_type_table> ORDER BY col_name order**.
-It returns a record list, or an empty list if the table is empty.
+It returns a record list, or an empty list if the table is empty. If a record class is specified in *cls*, this class
+will be used as record_type instead of the repository definition. Supports both `@fieldmapper` classes and plain classes
+such as dataclasses.
 
 Example:
 ```python

--- a/docs/classes/select.md
+++ b/docs/classes/select.md
@@ -173,7 +173,15 @@ qry = (
     .where('name', 'IS NOT NULL')
     .where('cp', 'IN', [100, 200, 300, 400])
 )
-# output: ('SELECT "foo".* FROM "foo" WHERE ("id" > %s) AND ("name" IS NOT NULL) AND ("cp" IN %s)', [5, [100, 200, 300, 400]])
+# output: ('SELECT "foo".* FROM "foo" WHERE ("id" > %s) AND ("name" IS NOT NULL) AND ("cp" IN (%s, %s, %s, %s))', [5, 100, 200, 300, 400])
+print(qry.assemble())
+
+# WHERE NOT IN with a list of values
+qry = (
+    Select(PgSqlDialect()).from_("foo")
+    .where('status', 'NOT IN', ['inactive', 'deleted'])
+)
+# output: ('SELECT "foo".* FROM "foo" WHERE ("status" NOT IN (%s, %s))', ['inactive', 'deleted'])
 print(qry.assemble())
 ```
 
@@ -203,7 +211,7 @@ qry = (
     .orwhere("cp", "IN", [100, 200, 300, 400])
     .where_end()
 )
-# output: ('SELECT "foo".* FROM "foo" WHERE ("id" > %s) AND ( ("name" IS NOT NULL) OR ("cp" IN %s) )', [5, [100, 200, 300, 400]])
+# output: ('SELECT "foo".* FROM "foo" WHERE ("id" > %s) AND ( ("name" IS NOT NULL) OR ("cp" IN (%s, %s, %s, %s)) )', [5, 100, 200, 300, 400])
 print(qry.assemble())
 
 ```
@@ -220,7 +228,7 @@ Example:
 
 ```python
 # showcase WHERE clause OR ( clause AND clause)
-qry = ( 
+qry = (
     Select(PgSqlDialect())
     .from_("foo")
     .where('id', '>', 5)
@@ -229,7 +237,7 @@ qry = (
     .where('cp', 'IN', [100, 200, 300, 400])
     .where_end()
 )
-# output: ('SELECT "foo".* FROM "foo" WHERE ("id" > %s) OR ( ("name" IS NOT NULL) AND ("cp" IN %s) )', [5, [100, 200, 300, 400]])
+# output: ('SELECT "foo".* FROM "foo" WHERE ("id" > %s) OR ( ("name" IS NOT NULL) AND ("cp" IN (%s, %s, %s, %s)) )', [5, 100, 200, 300, 400])
 print(qry.assemble())
 
 ```
@@ -261,7 +269,7 @@ qry = (
     .orwhere('name', 'IS NOT NULL')
     .where('cp', 'IN', [100, 200, 300, 400])
 )
-# output: ('SELECT "foo".* FROM "foo" WHERE ("id" > %s) OR ("name" IS NOT NULL) AND ("cp" IN %s)', [5, [100, 200, 300, 400]])
+# output: ('SELECT "foo".* FROM "foo" WHERE ("id" > %s) OR ("name" IS NOT NULL) AND ("cp" IN (%s, %s, %s, %s))', [5, 100, 200, 300, 400])
 print(qry.assemble())
 ```
 

--- a/docs/classes/select.md
+++ b/docs/classes/select.md
@@ -102,6 +102,27 @@ A column identifier can be None ('*' will be used), a string with a field name, 
 {'field': 'alias'} dict, a {'field': None, 'other_field':'alias} dict, or a [{'field': 'alias'}, 'field', ] list
 of mixed string and dict values.
 
+[Fn](fn.md) helpers can be used as dict keys for SQL functions with aliases:
+
+```python
+from rick_db.sql import Select, Fn, PgSqlDialect
+
+# Multiple columns with aggregates
+qry, _ = (
+    Select(PgSqlDialect())
+    .from_("orders", {
+        "category": None,
+        Fn.count(): "order_count",
+        Fn.sum("amount"): "total_amount",
+        Fn.round(Fn.avg("amount"), 2): "avg_rounded",
+    })
+    .group("category")
+    .assemble()
+)
+# output: SELECT "category",COUNT(*) AS "order_count",SUM(amount) AS "total_amount",ROUND(AVG(amount), 2) AS "avg_rounded" FROM "orders" GROUP BY "category"
+print(qry)
+```
+
 ### Select.**limit(limit: int, offset: int = None)**
 
 Adds an **LIMIT**/**OFFSET** clause.

--- a/docs/classes/update.md
+++ b/docs/classes/update.md
@@ -101,6 +101,26 @@ qry = (
 )
 # output: ('UPDATE "table" SET "field"=%s WHERE "id" = %s AND "name" ILIKE %s', ['value', 7, 'john%'])
 print(qry.assemble())
+
+# UPDATE WHERE... IN with a list of values
+qry = (
+    Update(PgSqlDialect())
+    .table("table")
+    .values({"field": "value"})
+    .where("id", "IN", [1, 2, 3])
+)
+# output: ('UPDATE "table" SET "field"=%s WHERE "id" IN (%s, %s, %s)', ['value', 1, 2, 3])
+print(qry.assemble())
+
+# UPDATE WHERE... NOT IN
+qry = (
+    Update(PgSqlDialect())
+    .table("table")
+    .values({"field": "value"})
+    .where("status", "NOT IN", ["archived", "deleted"])
+)
+# output: ('UPDATE "table" SET "field"=%s WHERE "status" NOT IN (%s, %s)', ['value', 'archived', 'deleted'])
+print(qry.assemble())
 ```
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
   - Update: 'classes/update.md'
   - Delete: 'classes/delete.md'
   - Literal: 'classes/literal.md'
+  - Fn: 'classes/fn.md'
   - JsonField: 'classes/jsonfield.md'
   - PgJsonField: 'classes/pgjsonfield.md'
   - CTEs (With): 'classes/with.md'

--- a/rick_db/connection.py
+++ b/rick_db/connection.py
@@ -250,10 +250,12 @@ class Cursor(CursorInterface):
             return []
 
         if cls is not None:
-            tmp = []
-            for r in result:
-                tmp.append(cls().fromrecord(r))
-            return tmp
+            if hasattr(cls, 'fromrecord'):
+                tmp = []
+                for r in result:
+                    tmp.append(cls().fromrecord(r))
+                return tmp
+            return [cls(**dict(r)) for r in result]
 
         return result
 
@@ -282,7 +284,9 @@ class Cursor(CursorInterface):
             return result
 
         if cls is not None:
-            return cls().fromrecord(result)
+            if hasattr(cls, 'fromrecord'):
+                return cls().fromrecord(result)
+            return cls(**dict(result))
         return result
 
     def fetchall(self, qry: str, params=None, cls=None) -> Optional[List]:
@@ -311,8 +315,10 @@ class Cursor(CursorInterface):
             return []
 
         if cls is not None:
-            tmp = []
-            for r in result:
-                tmp.append(cls().fromrecord(r))
-            return tmp
+            if hasattr(cls, 'fromrecord'):
+                tmp = []
+                for r in result:
+                    tmp.append(cls().fromrecord(r))
+                return tmp
+            return [cls(**dict(r)) for r in result]
         return result

--- a/rick_db/repository.py
+++ b/rick_db/repository.py
@@ -239,10 +239,11 @@ class Repository(GenericRepository):
         with self.cursor() as c:
             return c.fetchone(qry, values, self._record)
 
-    def fetch_one(self, qry: Select) -> Optional[object]:
+    def fetch_one(self, qry: Select, cls=None) -> Optional[object]:
         """
         Retrieve a single row
         :param qry: query to execute
+        :param cls: optional record class
         :return: record object of self._record or None
 
         Example:
@@ -250,7 +251,7 @@ class Repository(GenericRepository):
         """
         with self.cursor() as c:
             sql, values = qry.limit(1).assemble()
-            return c.fetchone(sql, values, cls=self._record)
+            return c.fetchone(sql, values, cls=cls or self._record)
 
     def fetch(self, qry: Select, cls=None) -> Optional[list]:
         """
@@ -284,20 +285,21 @@ class Repository(GenericRepository):
             sql, values = qry.assemble()
             return c.fetchall(sql, values)
 
-    def fetch_by_field(self, field, value, cols=None):
+    def fetch_by_field(self, field, value, cols=None, cls=None):
         """
         Fetch a list of rows where field=value
 
         :param field: field name
         :param value: value to match
         :param cols: optional columns to return
+        :param cls: optional record class
         :return: list of record object or empty list
         """
         qry, values = self.select(cols=cols).where(field, "=", value).assemble()
         with self.cursor() as c:
-            return c.fetchall(qry, values, self._record)
+            return c.fetchall(qry, values, cls or self._record)
 
-    def fetch_where(self, where_clauses: list, cols=None) -> list:
+    def fetch_where(self, where_clauses: list, cols=None, cls=None) -> list:
         """
         Fetch a list of rows that match a list of AND'ed WHERE clauses
 
@@ -322,9 +324,9 @@ class Repository(GenericRepository):
 
         qry, values = qry.assemble()
         with self.cursor() as c:
-            return c.fetchall(qry, values, self._record)
+            return c.fetchall(qry, values, cls or self._record)
 
-    def fetch_all(self) -> list:
+    def fetch_all(self, cls=None) -> list:
         """
         Fetch all rows
 
@@ -337,9 +339,9 @@ class Repository(GenericRepository):
             self.query_cache.set("fetch_all", qry)
 
         with self.cursor() as c:
-            return c.fetchall(qry, (), self._record)
+            return c.fetchall(qry, (), cls or self._record)
 
-    def fetch_all_ordered(self, col_name: str, order=Sql.SQL_ASC) -> list:
+    def fetch_all_ordered(self, col_name: str, order=Sql.SQL_ASC, cls=None) -> list:
         """
         Fetch all rows sorted by a column
         :param col_name: name of column to order by
@@ -348,7 +350,7 @@ class Repository(GenericRepository):
         """
         qry, _ = self.select().order(col_name, order).assemble()
         with self.cursor() as c:
-            return c.fetchall(qry, (), self._record)
+            return c.fetchall(qry, (), cls or self._record)
 
     def insert(self, record, cols=None) -> Optional[object]:
         """

--- a/rick_db/sql/__init__.py
+++ b/rick_db/sql/__init__.py
@@ -1,4 +1,4 @@
-from .common import SqlError, SqlStatement, Sql, Literal, L, JsonField, PgJsonField
+from .common import SqlError, SqlStatement, Sql, Literal, L, Fn, JsonField, PgJsonField
 from .dialect import SqlDialect, Sqlite3SqlDialect, PgSqlDialect, DefaultSqlDialect, ClickHouseSqlDialect, MySqlSqlDialect
 from .select import Select
 from .insert import Insert
@@ -12,6 +12,7 @@ __all__ = [
     "Sql",
     "Literal",
     "L",
+    "Fn",
     "JsonField",
     "PgJsonField",
     "SqlDialect",

--- a/rick_db/sql/common.py
+++ b/rick_db/sql/common.py
@@ -193,6 +193,87 @@ class PgJsonField(JsonField):
         return f"{self.field_name}::json"
 
 
+class Fn:
+    """
+    SQL function helpers that return Literal instances.
+
+    Use with dict-style column definitions for aliasing:
+        Select(dialect).from_(User, {Fn.count("*"): "total"})
+        Select(dialect).from_(User, {User.name: None, Fn.sum("amount"): "total_amount"})
+    """
+
+    # Aggregate functions
+    @staticmethod
+    def count(field="*"):
+        return Literal("COUNT({})".format(field))
+
+    @staticmethod
+    def sum(field):
+        return Literal("SUM({})".format(field))
+
+    @staticmethod
+    def avg(field):
+        return Literal("AVG({})".format(field))
+
+    @staticmethod
+    def min(field):
+        return Literal("MIN({})".format(field))
+
+    @staticmethod
+    def max(field):
+        return Literal("MAX({})".format(field))
+
+    # Math functions
+    @staticmethod
+    def abs(field):
+        return Literal("ABS({})".format(field))
+
+    @staticmethod
+    def ceil(field):
+        return Literal("CEIL({})".format(field))
+
+    @staticmethod
+    def floor(field):
+        return Literal("FLOOR({})".format(field))
+
+    @staticmethod
+    def round(field, decimals=None):
+        if decimals is not None:
+            return Literal("ROUND({}, {})".format(field, int(decimals)))
+        return Literal("ROUND({})".format(field))
+
+    @staticmethod
+    def power(field, exponent):
+        return Literal("POWER({}, {})".format(field, exponent))
+
+    @staticmethod
+    def sqrt(field):
+        return Literal("SQRT({})".format(field))
+
+    @staticmethod
+    def mod(field, divisor):
+        return Literal("MOD({}, {})".format(field, divisor))
+
+    @staticmethod
+    def sign(field):
+        return Literal("SIGN({})".format(field))
+
+    @staticmethod
+    def trunc(field, decimals=None):
+        if decimals is not None:
+            return Literal("TRUNC({}, {})".format(field, int(decimals)))
+        return Literal("TRUNC({})".format(field))
+
+    # General functions
+    @staticmethod
+    def coalesce(*fields):
+        return Literal("COALESCE({})".format(", ".join(str(f) for f in fields)))
+
+    @staticmethod
+    def cast(field, type_name):
+        return Literal("CAST({} AS {})".format(field, type_name))
+
+
 class Sql:
     DISTINCT = "distinct"
     COLUMNS = "columns"

--- a/rick_db/sql/delete.py
+++ b/rick_db/sql/delete.py
@@ -108,8 +108,7 @@ class Delete(SqlStatement):
                 expression = "{fld} {op}".format(fld=field, op=operator)
             self._clauses.append([expression, concat])
         else:
-            # sanity check, as we actually may have value list if subquery is in use
-            if isinstance(value, (list, tuple, dict)):
+            if isinstance(value, dict):
                 raise SqlError("_where(): invalid value type: %s" % str(type(value)))
 
             if operator is None:
@@ -117,7 +116,18 @@ class Delete(SqlStatement):
                     fld=field, ph=self._dialect.placeholder
                 )
             else:
-                if isinstance(value, Select):
+                if isinstance(value, (list, tuple)) and operator.lower() in ("in", "not in"):
+                    if len(value) == 0:
+                        raise SqlError("_where(): empty list for IN clause")
+                    placeholders = ", ".join([self._dialect.placeholder] * len(value))
+                    expression = "{fld} {op} ({phs})".format(
+                        fld=field, op=operator.upper(), phs=placeholders
+                    )
+                    self._values.extend(value)
+                    value = None
+                elif isinstance(value, (list, tuple)):
+                    raise SqlError("_where(): invalid value type: %s" % str(type(value)))
+                elif isinstance(value, Select):
                     sql, value = value.assemble()
                     expression = "{fld} {op} ({query})".format(
                         fld=field, op=operator, query=sql
@@ -128,10 +138,11 @@ class Delete(SqlStatement):
                     )
 
             self._clauses.append([expression, concat])
-            if isinstance(value, list):
-                self._values.extend(value)
-            else:
-                self._values.append(value)
+            if value is not None:
+                if isinstance(value, list):
+                    self._values.extend(value)
+                else:
+                    self._values.append(value)
         return self
 
     def assemble(self):

--- a/rick_db/sql/select.py
+++ b/rick_db/sql/select.py
@@ -929,7 +929,17 @@ class Select(SqlStatement):
                     fld=field, ph=self._dialect.placeholder
                 )
             else:
-                if isinstance(value, Select):
+                if isinstance(value, (list, tuple)) and operator is not None and operator.lower() in ("in", "not in"):
+                    if len(value) == 0:
+                        raise SqlError("_where(): empty list for IN clause")
+                    placeholders = ", ".join([self._dialect.placeholder] * len(value))
+                    expression = "{fld} {op} ({phs})".format(
+                        fld=field, op=operator.upper(), phs=placeholders
+                    )
+                    for v in value:
+                        self._query_values[Sql.WHERE].append(v)
+                    value = None
+                elif isinstance(value, Select):
                     sql, value = value.assemble()
                     expression = "{fld} {op} ({query})".format(
                         fld=field, op=operator, query=sql

--- a/rick_db/sql/update.py
+++ b/rick_db/sql/update.py
@@ -155,8 +155,7 @@ class Update(SqlStatement):
                 expression = "{fld} {op}".format(fld=field, op=operator)
             self._clauses.append([expression, concat])
         else:
-            # sanity check, as we actually may have value list if subquery is in use
-            if isinstance(value, (list, tuple, dict)):
+            if isinstance(value, dict):
                 raise SqlError("_where(): invalid value type: %s" % str(type(value)))
 
             if operator is None:
@@ -164,7 +163,18 @@ class Update(SqlStatement):
                     fld=field, ph=self._dialect.placeholder
                 )
             else:
-                if isinstance(value, Select):
+                if isinstance(value, (list, tuple)) and operator.lower() in ("in", "not in"):
+                    if len(value) == 0:
+                        raise SqlError("_where(): empty list for IN clause")
+                    placeholders = ", ".join([self._dialect.placeholder] * len(value))
+                    expression = "{fld} {op} ({phs})".format(
+                        fld=field, op=operator.upper(), phs=placeholders
+                    )
+                    self._clause_values.extend(value)
+                    value = None
+                elif isinstance(value, (list, tuple)):
+                    raise SqlError("_where(): invalid value type: %s" % str(type(value)))
+                elif isinstance(value, Select):
                     sql, value = value.assemble()
                     expression = "{fld} {op} ({query})".format(
                         fld=field, op=operator, query=sql
@@ -175,10 +185,11 @@ class Update(SqlStatement):
                     )
 
             self._clauses.append([expression, concat])
-            if isinstance(value, list):
-                self._clause_values.extend(value)
-            else:
-                self._clause_values.append(value)
+            if value is not None:
+                if isinstance(value, list):
+                    self._clause_values.extend(value)
+                else:
+                    self._clause_values.append(value)
         return self
 
     def returning(self, fields: Union[list, str] = None):

--- a/rick_db/version.py
+++ b/rick_db/version.py
@@ -1,4 +1,4 @@
-RICK_DB_VERSION = ["2", "2", "0"]
+RICK_DB_VERSION = ["2", "2", "1"]
 
 
 def get_version():

--- a/tests/repository/base_repository.py
+++ b/tests/repository/base_repository.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 import pytest
 from rick_db import fieldmapper, Repository, RepositoryError
 
@@ -14,6 +16,12 @@ class User:
 @fieldmapper
 class UserName:
     name = "name"
+
+
+@dataclass
+class UserDataclass:
+    name: str
+    email: str
 
 
 class BaseRepositoryTest:
@@ -183,6 +191,112 @@ class BaseRepositoryTest:
         # empty where_list
         with pytest.raises(RepositoryError):
             repo.fetch_where([])
+
+    def test_fetch_where_in(self, conn):
+        repo = Repository(conn, User)
+        # fetch with IN clause
+        records = repo.fetch_where([(User.name, "in", ["gandalf", "bilbo"])])
+        assert len(records) == 2
+        names = {r.name for r in records}
+        assert names == {"gandalf", "bilbo"}
+
+        # fetch with NOT IN clause
+        records = repo.fetch_where(
+            [(User.name, "not in", ["gandalf", "bilbo", "gollum"])]
+        )
+        assert len(records) == 2
+        names = {r.name for r in records}
+        assert names == {"aragorn", "samwise"}
+
+        # IN with single value
+        records = repo.fetch_where([(User.name, "in", ["aragorn"])])
+        assert len(records) == 1
+        assert records[0].name == "aragorn"
+
+        # IN combined with other conditions
+        records = repo.fetch_where(
+            [(User.name, "in", ["gandalf", "bilbo", "aragorn"]), (User.login, "=", "gandalf")]
+        )
+        assert len(records) == 1
+        assert records[0].name == "gandalf"
+
+    def test_fetch_one_cls(self, conn, fixture_users):
+        repo = Repository(conn, User)
+        # with fieldmapper class
+        record = repo.fetch_one(
+            repo.select(cols=[User.name, User.email]).where(User.name, "=", "gandalf"),
+            cls=UserName,
+        )
+        assert isinstance(record, UserName)
+        assert record.name == "gandalf"
+
+        # with dataclass
+        record = repo.fetch_one(
+            repo.select(cols=[User.name, User.email]).where(User.name, "=", "gandalf"),
+            cls=UserDataclass,
+        )
+        assert isinstance(record, UserDataclass)
+        assert record.name == "gandalf"
+        assert record.email is not None
+
+    def test_fetch_by_field_cls(self, conn, fixture_users):
+        repo = Repository(conn, User)
+        # with fieldmapper class
+        records = repo.fetch_by_field(User.name, "gandalf", cols=[User.name], cls=UserName)
+        assert len(records) == 1
+        assert isinstance(records[0], UserName)
+        assert records[0].name == "gandalf"
+
+        # with dataclass
+        records = repo.fetch_by_field(
+            User.name, "gandalf", cols=[User.name, User.email], cls=UserDataclass
+        )
+        assert len(records) == 1
+        assert isinstance(records[0], UserDataclass)
+        assert records[0].name == "gandalf"
+
+    def test_fetch_where_cls(self, conn, fixture_users):
+        repo = Repository(conn, User)
+        # with fieldmapper class
+        records = repo.fetch_where(
+            [(User.name, "=", "gandalf")], cols=[User.name], cls=UserName
+        )
+        assert len(records) == 1
+        assert isinstance(records[0], UserName)
+        assert records[0].name == "gandalf"
+
+        # with dataclass
+        records = repo.fetch_where(
+            [(User.name, "=", "gandalf")], cols=[User.name, User.email], cls=UserDataclass
+        )
+        assert len(records) == 1
+        assert isinstance(records[0], UserDataclass)
+        assert records[0].name == "gandalf"
+
+    def test_fetch_all_cls(self, conn, fixture_users):
+        repo = Repository(conn, User)
+        # with fieldmapper class
+        records = repo.fetch_all(cls=UserName)
+        assert len(records) == len(fixture_users)
+        for r in records:
+            assert isinstance(r, UserName)
+            assert r.name is not None
+
+        # with dataclass - need to select only matching columns
+        # fetch_all uses cached query (SELECT *), so dataclass must accept all columns
+        # Instead, use fetch() which is more flexible
+        # This test verifies fetch_all works with fieldmapper cls
+
+    def test_fetch_all_ordered_cls(self, conn, fixture_users):
+        repo = Repository(conn, User)
+        # with fieldmapper class
+        records = repo.fetch_all_ordered(User.name, cls=UserName)
+        assert len(records) == len(fixture_users)
+        for r in records:
+            assert isinstance(r, UserName)
+        # verify ordering
+        names = [r.name for r in records]
+        assert names == sorted(names)
 
     def test_insert(self, conn):
         repo = Repository(conn, User)

--- a/tests/sql/select/test_where.py
+++ b/tests/sql/select/test_where.py
@@ -415,3 +415,36 @@ class TestWhere:
         with pytest.raises(SqlError) as excinfo:
             select.assemble()
         assert "Unclosed AND block" in str(excinfo.value)
+
+    def test_where_in_list(self):
+        qry = Select(PgSqlDialect()).from_(SomeRecord).where(SomeRecord.field, "in", [1, 2, 3])
+        sql, values = qry.assemble()
+        assert sql == 'SELECT "test_table".* FROM "test_table" WHERE ("field" IN (%s, %s, %s))'
+        assert values == [1, 2, 3]
+
+    def test_where_not_in_list(self):
+        qry = Select(PgSqlDialect()).from_(SomeRecord).where(SomeRecord.field, "not in", [4, 5])
+        sql, values = qry.assemble()
+        assert sql == 'SELECT "test_table".* FROM "test_table" WHERE ("field" NOT IN (%s, %s))'
+        assert values == [4, 5]
+
+    def test_where_in_tuple(self):
+        qry = Select(PgSqlDialect()).from_(SomeRecord).where(SomeRecord.field, "in", (1, 2))
+        sql, values = qry.assemble()
+        assert sql == 'SELECT "test_table".* FROM "test_table" WHERE ("field" IN (%s, %s))'
+        assert values == [1, 2]
+
+    def test_where_in_empty_list(self):
+        with pytest.raises(SqlError):
+            Select(PgSqlDialect()).from_(SomeRecord).where(SomeRecord.field, "in", [])
+
+    def test_where_in_with_other_clauses(self):
+        qry = (
+            Select(PgSqlDialect())
+            .from_(SomeRecord)
+            .where(SomeRecord.field, "in", [1, 2, 3])
+            .where("other", "=", "abc")
+        )
+        sql, values = qry.assemble()
+        assert sql == 'SELECT "test_table".* FROM "test_table" WHERE ("field" IN (%s, %s, %s)) AND ("other" = %s)'
+        assert values == [1, 2, 3, "abc"]

--- a/tests/sql/test_delete.py
+++ b/tests/sql/test_delete.py
@@ -104,6 +104,25 @@ def delete_cases_or():
     ]
 
 
+def delete_cases_in():
+    return [
+        [
+            "table1",
+            [("id", "in", [1, 2, 3])],
+            None,
+            'DELETE FROM "table1" WHERE "id" IN (?, ?, ?)',
+            [1, 2, 3],
+        ],
+        [
+            "table1",
+            [("id", "not in", [4, 5])],
+            None,
+            'DELETE FROM "table1" WHERE "id" NOT IN (?, ?)',
+            [4, 5],
+        ],
+    ]
+
+
 def delete_cases_and_or():
     sample_query = Select().from_("test", ["id"]).where("field", "=", "abcd")
     return [
@@ -129,6 +148,16 @@ class TestDelete:
 
         sql, _ = qry.assemble()
         assert sql == result
+
+    @pytest.mark.parametrize("table, where_list, schema, result, expected_values", delete_cases_in())
+    def test_delete_where_in(self, table, where_list, schema, result, expected_values):
+        qry = Delete().from_(table, schema)
+        for item in where_list:
+            field, operator, value = item
+            qry.where(field, operator, value)
+        sql, values = qry.assemble()
+        assert sql == result
+        assert values == expected_values
 
     @pytest.mark.parametrize("table, where_list, schema, result", delete_cases_or())
     def test_delete_or(self, table, where_list, schema, result):

--- a/tests/sql/test_fn.py
+++ b/tests/sql/test_fn.py
@@ -1,0 +1,85 @@
+from rick_db.sql import Fn, Literal, Select, PgSqlDialect
+
+
+class TestFn:
+
+    def test_count(self):
+        result = Fn.count()
+        assert isinstance(result, Literal)
+        assert str(result) == "COUNT(*)"
+
+    def test_count_field(self):
+        assert str(Fn.count("id")) == "COUNT(id)"
+
+    def test_sum(self):
+        assert str(Fn.sum("amount")) == "SUM(amount)"
+
+    def test_avg(self):
+        assert str(Fn.avg("price")) == "AVG(price)"
+
+    def test_min(self):
+        assert str(Fn.min("price")) == "MIN(price)"
+
+    def test_max(self):
+        assert str(Fn.max("price")) == "MAX(price)"
+
+    def test_abs(self):
+        assert str(Fn.abs("value")) == "ABS(value)"
+
+    def test_ceil(self):
+        assert str(Fn.ceil("value")) == "CEIL(value)"
+
+    def test_floor(self):
+        assert str(Fn.floor("value")) == "FLOOR(value)"
+
+    def test_round(self):
+        assert str(Fn.round("value")) == "ROUND(value)"
+
+    def test_round_decimals(self):
+        assert str(Fn.round("value", 2)) == "ROUND(value, 2)"
+
+    def test_power(self):
+        assert str(Fn.power("value", 3)) == "POWER(value, 3)"
+
+    def test_sqrt(self):
+        assert str(Fn.sqrt("value")) == "SQRT(value)"
+
+    def test_mod(self):
+        assert str(Fn.mod("value", 3)) == "MOD(value, 3)"
+
+    def test_sign(self):
+        assert str(Fn.sign("value")) == "SIGN(value)"
+
+    def test_trunc(self):
+        assert str(Fn.trunc("value")) == "TRUNC(value)"
+
+    def test_trunc_decimals(self):
+        assert str(Fn.trunc("value", 2)) == "TRUNC(value, 2)"
+
+    def test_coalesce(self):
+        assert str(Fn.coalesce("a", "b", "c")) == "COALESCE(a, b, c)"
+
+    def test_cast(self):
+        assert str(Fn.cast("field", "int")) == "CAST(field AS int)"
+
+    def test_select_with_fn(self):
+        dialect = PgSqlDialect()
+        qry, _ = Select(dialect).from_("users", {Fn.count(): "total"}).assemble()
+        assert 'COUNT(*)' in qry
+        assert '"total"' in qry
+
+    def test_select_mixed_columns(self):
+        dialect = PgSqlDialect()
+        qry, _ = (
+            Select(dialect)
+            .from_("orders", {"name": None, Fn.sum("amount"): "total"})
+            .group("name")
+            .assemble()
+        )
+        assert '"name"' in qry
+        assert 'SUM(amount)' in qry
+        assert '"total"' in qry
+
+    def test_nested_fn(self):
+        result = Fn.round(Fn.avg("price"), 2)
+        assert str(result) == "ROUND(AVG(price), 2)"

--- a/tests/sql/test_fn_integration.py
+++ b/tests/sql/test_fn_integration.py
@@ -1,0 +1,208 @@
+import pytest
+from rick_db import fieldmapper, Repository
+from rick_db.backend.sqlite import Sqlite3Connection
+from rick_db.sql import Fn, Select, Sqlite3SqlDialect
+
+
+@fieldmapper(tablename="products", pk="id")
+class Product:
+    id = "id"
+    category = "category"
+    name = "name"
+    price = "price"
+    quantity = "quantity"
+
+
+create_table = """
+    create table if not exists products(
+    id integer primary key autoincrement,
+    category text not null,
+    name text not null,
+    price real not null,
+    quantity integer not null
+    );
+"""
+
+insert_row = "insert into products(category, name, price, quantity) values(?,?,?,?)"
+
+PRODUCTS = [
+    ("electronics", "keyboard", 49.99, 10),
+    ("electronics", "mouse", 29.50, 25),
+    ("electronics", "monitor", 299.99, 5),
+    ("furniture", "desk", 199.00, 8),
+    ("furniture", "chair", 149.50, 12),
+    ("furniture", "lamp", -15.75, 0),  # negative price for abs/sign tests
+]
+
+
+@pytest.fixture
+def conn():
+    conn = Sqlite3Connection(":memory:")
+    with conn.cursor() as c:
+        c.exec(create_table)
+        for row in PRODUCTS:
+            c.exec(insert_row, list(row))
+    yield conn
+    conn.close()
+
+
+class TestFnIntegration:
+
+    def test_count(self, conn):
+        repo = Repository(conn, Product)
+        qry = repo.select({Fn.count(): "total"})
+        rows = repo.fetch_raw(qry)
+        assert rows[0]["total"] == len(PRODUCTS)
+
+    def test_count_field(self, conn):
+        repo = Repository(conn, Product)
+        qry = repo.select({Fn.count(Product.name): "total"})
+        rows = repo.fetch_raw(qry)
+        assert rows[0]["total"] == len(PRODUCTS)
+
+    def test_sum(self, conn):
+        repo = Repository(conn, Product)
+        qry = repo.select({Fn.sum(Product.quantity): "total_qty"})
+        rows = repo.fetch_raw(qry)
+        expected = sum(p[3] for p in PRODUCTS)
+        assert rows[0]["total_qty"] == expected
+
+    def test_avg(self, conn):
+        repo = Repository(conn, Product)
+        qry = repo.select({Fn.avg(Product.price): "avg_price"})
+        rows = repo.fetch_raw(qry)
+        expected = sum(p[2] for p in PRODUCTS) / len(PRODUCTS)
+        assert abs(rows[0]["avg_price"] - expected) < 0.01
+
+    def test_min(self, conn):
+        repo = Repository(conn, Product)
+        qry = repo.select({Fn.min(Product.price): "min_price"})
+        rows = repo.fetch_raw(qry)
+        assert rows[0]["min_price"] == min(p[2] for p in PRODUCTS)
+
+    def test_max(self, conn):
+        repo = Repository(conn, Product)
+        qry = repo.select({Fn.max(Product.price): "max_price"})
+        rows = repo.fetch_raw(qry)
+        assert rows[0]["max_price"] == max(p[2] for p in PRODUCTS)
+
+    def test_abs(self, conn):
+        repo = Repository(conn, Product)
+        qry = repo.select({Fn.abs(Product.price): "abs_price"}).where(
+            Product.price, "<", 0
+        )
+        rows = repo.fetch_raw(qry)
+        assert len(rows) == 1
+        assert rows[0]["abs_price"] == 15.75
+
+    def test_round(self, conn):
+        repo = Repository(conn, Product)
+        qry = repo.select(
+            {Fn.round(Fn.avg(Product.price), 1): "rounded"}
+        )
+        rows = repo.fetch_raw(qry)
+        expected = round(sum(p[2] for p in PRODUCTS) / len(PRODUCTS), 1)
+        assert rows[0]["rounded"] == expected
+
+    def test_round_no_decimals(self, conn):
+        repo = Repository(conn, Product)
+        qry = repo.select({Fn.round(Product.price): "rounded"}).where(
+            Product.name, "=", "keyboard"
+        )
+        rows = repo.fetch_raw(qry)
+        assert rows[0]["rounded"] == round(49.99)
+
+    def test_sign(self, conn):
+        repo = Repository(conn, Product)
+        qry = repo.select({Product.name: None, Fn.sign(Product.price): "sgn"}).order(
+            Product.id
+        )
+        rows = repo.fetch_raw(qry)
+        for row in rows:
+            if row["name"] == "lamp":
+                assert row["sgn"] == -1
+            else:
+                assert row["sgn"] == 1
+
+    def test_coalesce(self, conn):
+        repo = Repository(conn, Product)
+        qry = repo.select({Fn.coalesce(Product.category, "'unknown'"): "cat"}).limit(1)
+        rows = repo.fetch_raw(qry)
+        assert rows[0]["cat"] is not None
+
+    def test_group_by_with_aggregates(self, conn):
+        repo = Repository(conn, Product)
+        qry = (
+            repo.select(
+                {
+                    Product.category: None,
+                    Fn.count(): "cnt",
+                    Fn.sum(Product.quantity): "total_qty",
+                    Fn.avg(Product.price): "avg_price",
+                }
+            )
+            .group(Product.category)
+            .order(Product.category)
+        )
+        rows = repo.fetch_raw(qry)
+        assert len(rows) == 2
+
+        electronics = rows[0]
+        assert electronics["category"] == "electronics"
+        assert electronics["cnt"] == 3
+        assert electronics["total_qty"] == 40
+
+        furniture = rows[1]
+        assert furniture["category"] == "furniture"
+        assert furniture["cnt"] == 3
+        assert furniture["total_qty"] == 20
+
+    def test_nested_functions(self, conn):
+        repo = Repository(conn, Product)
+        # ROUND(AVG(price), 2) grouped by category
+        qry = (
+            repo.select(
+                {
+                    Product.category: None,
+                    Fn.round(Fn.avg(Product.price), 2): "avg_price",
+                }
+            )
+            .group(Product.category)
+            .order(Product.category)
+        )
+        rows = repo.fetch_raw(qry)
+        assert len(rows) == 2
+
+        elec_prices = [p[2] for p in PRODUCTS if p[0] == "electronics"]
+        expected = round(sum(elec_prices) / len(elec_prices), 2)
+        assert rows[0]["avg_price"] == expected
+
+    def test_having_with_fn(self, conn):
+        repo = Repository(conn, Product)
+        qry = (
+            repo.select({Product.category: None, Fn.sum(Product.quantity): "total_qty"})
+            .group(Product.category)
+            .having(Fn.sum(Product.quantity), ">", 30)
+        )
+        rows = repo.fetch_raw(qry)
+        assert len(rows) == 1
+        assert rows[0]["category"] == "electronics"
+
+    def test_mixed_columns_list_and_fn(self, conn):
+        repo = Repository(conn, Product)
+        # Use fn in a dict with regular columns
+        qry = (
+            repo.select(
+                {
+                    Product.category: None,
+                    Fn.min(Product.price): "cheapest",
+                    Fn.max(Product.price): "priciest",
+                }
+            )
+            .group(Product.category)
+            .order(Product.category)
+        )
+        rows = repo.fetch_raw(qry)
+        assert len(rows) == 2
+        assert rows[0]["cheapest"] == 29.50
+        assert rows[0]["priciest"] == 299.99

--- a/tests/sql/test_fn_integration_pg.py
+++ b/tests/sql/test_fn_integration_pg.py
@@ -1,0 +1,220 @@
+import pytest
+from rick_db import fieldmapper, Repository
+from rick_db.backend.pg import PgConnection
+from rick_db.sql import Fn
+
+
+@fieldmapper(tablename="test_products", pk="id")
+class Product:
+    id = "id"
+    category = "category"
+    name = "name"
+    price = "price"
+    quantity = "quantity"
+
+
+create_table = """
+    create table if not exists test_products(
+    id serial primary key,
+    category text not null,
+    name text not null,
+    price numeric(10,2) not null,
+    quantity integer not null
+    );
+"""
+
+insert_row = (
+    "insert into test_products(category, name, price, quantity) values(%s,%s,%s,%s)"
+)
+drop_table = "drop table if exists test_products"
+
+PRODUCTS = [
+    ("electronics", "keyboard", 49.99, 10),
+    ("electronics", "mouse", 29.50, 25),
+    ("electronics", "monitor", 299.99, 5),
+    ("furniture", "desk", 199.00, 8),
+    ("furniture", "chair", 149.50, 12),
+    ("furniture", "lamp", -15.75, 0),
+]
+
+
+@pytest.fixture
+def conn(pg_settings):
+    conn = PgConnection(**pg_settings)
+    with conn.cursor() as c:
+        c.exec(drop_table)
+        c.exec(create_table)
+        for row in PRODUCTS:
+            c.exec(insert_row, list(row))
+    yield conn
+    with conn.cursor() as c:
+        c.exec(drop_table)
+    conn.close()
+
+
+class TestFnIntegrationPg:
+
+    def test_count(self, conn):
+        repo = Repository(conn, Product)
+        qry = repo.select({Fn.count(): "total"})
+        rows = repo.fetch_raw(qry)
+        assert rows[0]["total"] == len(PRODUCTS)
+
+    def test_sum(self, conn):
+        repo = Repository(conn, Product)
+        qry = repo.select({Fn.sum(Product.quantity): "total_qty"})
+        rows = repo.fetch_raw(qry)
+        expected = sum(p[3] for p in PRODUCTS)
+        assert rows[0]["total_qty"] == expected
+
+    def test_avg(self, conn):
+        repo = Repository(conn, Product)
+        qry = repo.select({Fn.avg(Product.price): "avg_price"})
+        rows = repo.fetch_raw(qry)
+        expected = sum(p[2] for p in PRODUCTS) / len(PRODUCTS)
+        assert abs(float(rows[0]["avg_price"]) - expected) < 0.01
+
+    def test_min(self, conn):
+        repo = Repository(conn, Product)
+        qry = repo.select({Fn.min(Product.price): "min_price"})
+        rows = repo.fetch_raw(qry)
+        assert float(rows[0]["min_price"]) == min(p[2] for p in PRODUCTS)
+
+    def test_max(self, conn):
+        repo = Repository(conn, Product)
+        qry = repo.select({Fn.max(Product.price): "max_price"})
+        rows = repo.fetch_raw(qry)
+        assert float(rows[0]["max_price"]) == max(p[2] for p in PRODUCTS)
+
+    def test_abs(self, conn):
+        repo = Repository(conn, Product)
+        qry = repo.select({Fn.abs(Product.price): "abs_price"}).where(
+            Product.price, "<", 0
+        )
+        rows = repo.fetch_raw(qry)
+        assert len(rows) == 1
+        assert float(rows[0]["abs_price"]) == 15.75
+
+    def test_ceil(self, conn):
+        repo = Repository(conn, Product)
+        qry = repo.select({Fn.ceil(Product.price): "ceiled"}).where(
+            Product.name, "=", "keyboard"
+        )
+        rows = repo.fetch_raw(qry)
+        assert float(rows[0]["ceiled"]) == 50
+
+    def test_floor(self, conn):
+        repo = Repository(conn, Product)
+        qry = repo.select({Fn.floor(Product.price): "floored"}).where(
+            Product.name, "=", "keyboard"
+        )
+        rows = repo.fetch_raw(qry)
+        assert float(rows[0]["floored"]) == 49
+
+    def test_round(self, conn):
+        repo = Repository(conn, Product)
+        qry = repo.select({Fn.round(Fn.avg(Product.price), 1): "rounded"})
+        rows = repo.fetch_raw(qry)
+        expected = round(sum(p[2] for p in PRODUCTS) / len(PRODUCTS), 1)
+        assert float(rows[0]["rounded"]) == expected
+
+    def test_power(self, conn):
+        repo = Repository(conn, Product)
+        qry = repo.select({Fn.power(Product.quantity, 2): "squared"}).where(
+            Product.name, "=", "mouse"
+        )
+        rows = repo.fetch_raw(qry)
+        assert float(rows[0]["squared"]) == 625  # 25^2
+
+    def test_sqrt(self, conn):
+        repo = Repository(conn, Product)
+        qry = repo.select({Fn.sqrt(Product.quantity): "root"}).where(
+            Product.name, "=", "mouse"
+        )
+        rows = repo.fetch_raw(qry)
+        assert float(rows[0]["root"]) == 5.0  # sqrt(25)
+
+    def test_mod(self, conn):
+        repo = Repository(conn, Product)
+        qry = repo.select({Fn.mod(Product.quantity, 3): "remainder"}).where(
+            Product.name, "=", "mouse"
+        )
+        rows = repo.fetch_raw(qry)
+        assert rows[0]["remainder"] == 1  # 25 % 3
+
+    def test_sign(self, conn):
+        repo = Repository(conn, Product)
+        qry = repo.select({Product.name: None, Fn.sign(Product.price): "sgn"}).where(
+            Product.name, "in", ["keyboard", "lamp"]
+        ).order(Product.id)
+        rows = repo.fetch_raw(qry)
+        assert rows[0]["sgn"] == 1
+        assert rows[1]["sgn"] == -1
+
+    def test_trunc(self, conn):
+        repo = Repository(conn, Product)
+        qry = repo.select({Fn.trunc(Product.price, 1): "truncated"}).where(
+            Product.name, "=", "keyboard"
+        )
+        rows = repo.fetch_raw(qry)
+        assert float(rows[0]["truncated"]) == 49.9
+
+    def test_trunc_no_decimals(self, conn):
+        repo = Repository(conn, Product)
+        qry = repo.select({Fn.trunc(Product.price): "truncated"}).where(
+            Product.name, "=", "keyboard"
+        )
+        rows = repo.fetch_raw(qry)
+        assert float(rows[0]["truncated"]) == 49
+
+    def test_coalesce(self, conn):
+        repo = Repository(conn, Product)
+        qry = repo.select({Fn.coalesce(Product.category, "'unknown'"): "cat"}).limit(1)
+        rows = repo.fetch_raw(qry)
+        assert rows[0]["cat"] is not None
+
+    def test_cast(self, conn):
+        repo = Repository(conn, Product)
+        qry = repo.select({Fn.cast(Product.price, "integer"): "int_price"}).where(
+            Product.name, "=", "keyboard"
+        )
+        rows = repo.fetch_raw(qry)
+        assert rows[0]["int_price"] == 50
+
+    def test_group_by_with_aggregates(self, conn):
+        repo = Repository(conn, Product)
+        qry = (
+            repo.select(
+                {
+                    Product.category: None,
+                    Fn.count(): "cnt",
+                    Fn.sum(Product.quantity): "total_qty",
+                    Fn.round(Fn.avg(Product.price), 2): "avg_price",
+                }
+            )
+            .group(Product.category)
+            .order(Product.category)
+        )
+        rows = repo.fetch_raw(qry)
+        assert len(rows) == 2
+
+        electronics = rows[0]
+        assert electronics["category"] == "electronics"
+        assert electronics["cnt"] == 3
+        assert electronics["total_qty"] == 40
+
+        furniture = rows[1]
+        assert furniture["category"] == "furniture"
+        assert furniture["cnt"] == 3
+        assert furniture["total_qty"] == 20
+
+    def test_having_with_fn(self, conn):
+        repo = Repository(conn, Product)
+        qry = (
+            repo.select({Product.category: None, Fn.sum(Product.quantity): "total_qty"})
+            .group(Product.category)
+            .having(Fn.sum(Product.quantity), ">", 30)
+        )
+        rows = repo.fetch_raw(qry)
+        assert len(rows) == 1
+        assert rows[0]["category"] == "electronics"

--- a/tests/sql/test_update.py
+++ b/tests/sql/test_update.py
@@ -259,6 +259,18 @@ class TestUpdate:
         sql, _ = qry.assemble()
         assert sql == result
 
+    def test_update_where_in(self):
+        qry = Update().table("table1").values({"field1": "value1"}).where("id", "in", [1, 2, 3])
+        sql, values = qry.assemble()
+        assert sql == 'UPDATE "table1" SET "field1"=? WHERE "id" IN (?, ?, ?)'
+        assert values == ["value1", 1, 2, 3]
+
+    def test_update_where_not_in(self):
+        qry = Update().table("table1").values({"field1": "value1"}).where("id", "not in", [4, 5])
+        sql, values = qry.assemble()
+        assert sql == 'UPDATE "table1" SET "field1"=? WHERE "id" NOT IN (?, ?)'
+        assert values == ["value1", 4, 5]
+
     @pytest.mark.parametrize(
         "table, fields, where_list, returning_list, schema, result", return_cases()
     )


### PR DESCRIPTION
## Summary by Sourcery

Add SQL function helper API, IN/NOT IN list handling, and flexible record class support across repository, connection, and query builders.

New Features:
- Introduce Fn helper class to construct SQL function expressions as Literals for use in Select queries and HAVING clauses.
- Support overriding repository record type via an optional cls parameter on fetch_one, fetch_by_field, fetch_where, fetch_all, and fetch_all_ordered, including plain classes and dataclasses.

Bug Fixes:
- Ensure Select, Update, and Delete builders correctly parameterize WHERE IN/NOT IN list and tuple values and reject invalid empty or dict value usages.

Enhancements:
- Extend connection cursor methods to instantiate result rows into either fieldmapper records or arbitrary classes via keyword construction when fromrecord is not available.
- Expand documentation and examples for IN/NOT IN usage, Fn helpers, and repository cls overrides, and expose Fn in the SQL public API and navigation.
- Add comprehensive tests for Fn helpers on SQLite and Postgres, repository cls behaviour, and IN/NOT IN handling in Select, Update, and Delete queries.