### PR TITLE
Optimize SQL query builder and record introspection performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [2.2.1]
 
+### Performance
+- Cache SQL identifier quoting (`_qi()`) with `@lru_cache` across all dialects, eliminating redundant string work on repeated field/table references
+- Replace `.format()` string building with f-strings throughout query builders (`select.py`, `insert.py`, `update.py`, `delete.py`, `dialect.py`, `common.py`)
+- Replace `list(dict.items()).pop()` anti-pattern with `next(iter(dict.items()))` in `Select._where()`, `having()`, `_join()`, `_parse_table_def()`
+- Remove unnecessary `.keys()` calls from dict membership tests in `Select` and `BaseRecord`
+- Single-pass `_render_from()` replaces three separate classification loops plus three rendering loops
+- Use `isinstance()` instead of `type() in [list, tuple]` checks in `Select`
+- Cache `Fn.count()` singleton for the common no-arg `COUNT(*)` case
+- Optimize `BaseRecord.asrecord()` to use dict comprehension instead of copy-and-pop loop
+- Simplify `BaseRecord.__getattribute__()` to use `dict.get()` instead of `in .keys()` + lookup
+- Replace `_valid_joins`/`_valid_unions`/`_valid_order` lists with `frozenset` for O(1) membership checks
+- Remove redundant `.strip()` from `Select.assemble()` by filtering empty parts and fixing root cause in `_render_order()`
+- Use `.extend()` instead of per-element `.append()` loops for value list copying
+
 ### Added
 - `Fn` helper class for common SQL functions in the query builder, returning `Literal` instances for use in column definitions
   - Aggregate: `count`, `sum`, `avg`, `min`, `max`

--- a/rick_db/mapper.py
+++ b/rick_db/mapper.py
@@ -114,7 +114,7 @@ class BaseRecord(Record):
         if pk is None:
             raise RecordError("primary key is not defined")
         row = self._row
-        if pk in row.keys():
+        if pk in row:
             return row[pk]
         raise AttributeError("primary key value is not set")
 
@@ -126,24 +126,21 @@ class BaseRecord(Record):
         result = {}
         data = self._row
         for key, dbfield in self._fieldmap.items():
-            if key not in skip and dbfield in data.keys():
+            if key not in skip and dbfield in data:
                 result[key] = data[dbfield]
         return result
 
     def asrecord(self):
-        dbfieldnames = object.__getattribute__(self, ATTR_FIELDS).values()
-        data = object.__getattribute__(self, ATTR_ROW).copy()
-        # remove entries that may exist in _row but do not map to allowed fields
-        for key in list(data.keys()):
-            if key not in dbfieldnames:
-                data.pop(key)
-        return data
+        fieldmap = object.__getattribute__(self, ATTR_FIELDS)
+        data = object.__getattribute__(self, ATTR_ROW)
+        dbfieldnames = fieldmap.values()
+        return {key: val for key, val in data.items() if key in dbfieldnames}
 
     def fields(self):
         result = []
         data = self._row
         for key, dbfield in self._fieldmap.items():
-            if dbfield in data.keys():
+            if dbfield in data:
                 result.append(key)
         return result
 
@@ -154,7 +151,7 @@ class BaseRecord(Record):
         result = []
         data = self._row
         for key, dbfield in self._fieldmap.items():
-            if dbfield in data.keys():
+            if dbfield in data:
                 result.append(data[dbfield])
         return result
 
@@ -178,12 +175,9 @@ class BaseRecord(Record):
         if attr in fieldmap:
             field = fieldmap[attr]
             data = object.__getattribute__(self, ATTR_ROW)
-            if field in data.keys():
-                return data[field]
-            return None
+            return data.get(field)
 
-        attribute = object.__getattribute__(self, attr)
-        return attribute
+        return object.__getattribute__(self, attr)
 
     def __setattr__(self, key, value):
         fm = object.__getattribute__(self, ATTR_FIELDS)
@@ -210,7 +204,9 @@ def _base_record_method_map() -> dict:
     return methods
 
 
-def fieldmapper(cls=None, pk=None, tablename=None, schema=None, clsonly=False, json_exclude=None):
+def fieldmapper(
+    cls=None, pk=None, tablename=None, schema=None, clsonly=False, json_exclude=None
+):
     def wrap(cls):
         fieldmap = {}
         if clsonly:

--- a/rick_db/sql/common.py
+++ b/rick_db/sql/common.py
@@ -202,76 +202,80 @@ class Fn:
         Select(dialect).from_(User, {User.name: None, Fn.sum("amount"): "total_amount"})
     """
 
+    _COUNT_STAR = Literal("COUNT(*)")
+
     # Aggregate functions
     @staticmethod
     def count(field="*"):
-        return Literal("COUNT({})".format(field))
+        if field == "*":
+            return Fn._COUNT_STAR
+        return Literal(f"COUNT({field})")
 
     @staticmethod
     def sum(field):
-        return Literal("SUM({})".format(field))
+        return Literal(f"SUM({field})")
 
     @staticmethod
     def avg(field):
-        return Literal("AVG({})".format(field))
+        return Literal(f"AVG({field})")
 
     @staticmethod
     def min(field):
-        return Literal("MIN({})".format(field))
+        return Literal(f"MIN({field})")
 
     @staticmethod
     def max(field):
-        return Literal("MAX({})".format(field))
+        return Literal(f"MAX({field})")
 
     # Math functions
     @staticmethod
     def abs(field):
-        return Literal("ABS({})".format(field))
+        return Literal(f"ABS({field})")
 
     @staticmethod
     def ceil(field):
-        return Literal("CEIL({})".format(field))
+        return Literal(f"CEIL({field})")
 
     @staticmethod
     def floor(field):
-        return Literal("FLOOR({})".format(field))
+        return Literal(f"FLOOR({field})")
 
     @staticmethod
     def round(field, decimals=None):
         if decimals is not None:
-            return Literal("ROUND({}, {})".format(field, int(decimals)))
-        return Literal("ROUND({})".format(field))
+            return Literal(f"ROUND({field}, {int(decimals)})")
+        return Literal(f"ROUND({field})")
 
     @staticmethod
     def power(field, exponent):
-        return Literal("POWER({}, {})".format(field, exponent))
+        return Literal(f"POWER({field}, {exponent})")
 
     @staticmethod
     def sqrt(field):
-        return Literal("SQRT({})".format(field))
+        return Literal(f"SQRT({field})")
 
     @staticmethod
     def mod(field, divisor):
-        return Literal("MOD({}, {})".format(field, divisor))
+        return Literal(f"MOD({field}, {divisor})")
 
     @staticmethod
     def sign(field):
-        return Literal("SIGN({})".format(field))
+        return Literal(f"SIGN({field})")
 
     @staticmethod
     def trunc(field, decimals=None):
         if decimals is not None:
-            return Literal("TRUNC({}, {})".format(field, int(decimals)))
-        return Literal("TRUNC({})".format(field))
+            return Literal(f"TRUNC({field}, {int(decimals)})")
+        return Literal(f"TRUNC({field})")
 
     # General functions
     @staticmethod
     def coalesce(*fields):
-        return Literal("COALESCE({})".format(", ".join(str(f) for f in fields)))
+        return Literal(f"COALESCE({', '.join(str(f) for f in fields)})")
 
     @staticmethod
     def cast(field, type_name):
-        return Literal("CAST({} AS {})".format(field, type_name))
+        return Literal(f"CAST({field} AS {type_name})")
 
 
 class Sql:

--- a/rick_db/sql/delete.py
+++ b/rick_db/sql/delete.py
@@ -103,39 +103,36 @@ class Delete(SqlStatement):
 
         if value is None:
             if operator is None:
-                expression = "{fld}".format(fld=field)
+                expression = field
             else:
-                expression = "{fld} {op}".format(fld=field, op=operator)
+                expression = f"{field} {operator}"
             self._clauses.append([expression, concat])
         else:
             if isinstance(value, dict):
                 raise SqlError("_where(): invalid value type: %s" % str(type(value)))
 
             if operator is None:
-                expression = "{fld} {ph}".format(
-                    fld=field, ph=self._dialect.placeholder
-                )
+                expression = f"{field} {self._dialect.placeholder}"
             else:
-                if isinstance(value, (list, tuple)) and operator.lower() in ("in", "not in"):
+                if isinstance(value, (list, tuple)) and operator.lower() in (
+                    "in",
+                    "not in",
+                ):
                     if len(value) == 0:
                         raise SqlError("_where(): empty list for IN clause")
                     placeholders = ", ".join([self._dialect.placeholder] * len(value))
-                    expression = "{fld} {op} ({phs})".format(
-                        fld=field, op=operator.upper(), phs=placeholders
-                    )
+                    expression = f"{field} {operator.upper()} ({placeholders})"
                     self._values.extend(value)
                     value = None
                 elif isinstance(value, (list, tuple)):
-                    raise SqlError("_where(): invalid value type: %s" % str(type(value)))
+                    raise SqlError(
+                        "_where(): invalid value type: %s" % str(type(value))
+                    )
                 elif isinstance(value, Select):
                     sql, value = value.assemble()
-                    expression = "{fld} {op} ({query})".format(
-                        fld=field, op=operator, query=sql
-                    )
+                    expression = f"{field} {operator} ({sql})"
                 else:
-                    expression = "{fld} {op} {ph}".format(
-                        fld=field, op=operator, ph=self._dialect.placeholder
-                    )
+                    expression = f"{field} {operator} {self._dialect.placeholder}"
 
             self._clauses.append([expression, concat])
             if value is not None:

--- a/rick_db/sql/dialect.py
+++ b/rick_db/sql/dialect.py
@@ -1,3 +1,5 @@
+from functools import lru_cache
+
 from rick_db.sql import SqlError, Literal
 
 
@@ -34,6 +36,7 @@ class SqlDialect:
             "JSON_CONTAINS_PATH({field}, 'one', {path})"  # Check if path exists
         )
 
+    @lru_cache(maxsize=256)
     def _qi(self, identifier):
         """
         Quote a SQL identifier, escaping embedded double-quotes by doubling them
@@ -43,7 +46,7 @@ class SqlDialect:
         :return: quoted identifier string, e.g. '"my_table"'
         """
         escaped = identifier.replace('"', '""')
-        return '"{}"'.format(escaped)
+        return f'"{escaped}"'
 
     def table(self, table_name, alias=None, schema=None):
         """
@@ -62,14 +65,10 @@ class SqlDialect:
             table_name = self._qi(table_name)
 
             if schema is not None:
-                table_name = (
-                    self._qi(schema)
-                    + self._separator
-                    + table_name
-                )
+                table_name = self._qi(schema) + self._separator + table_name
         else:
             # table_name is actually a Literal expression, just add parenthesis
-            table_name = "({table})".format(table=table_name)
+            table_name = f"({table_name})"
 
         if alias is None:
             return table_name
@@ -96,9 +95,7 @@ class SqlDialect:
         if table is not None:
             table = self._qi(table) + self._separator
             if schema is not None:
-                table = (
-                    self._qi(schema) + self._separator + table
-                )
+                table = self._qi(schema) + self._separator + table
         else:
             table = ""
 
@@ -119,9 +116,7 @@ class SqlDialect:
                 raise SqlError("Alias for field %s cannot be empty" % field)
             field = self._cast.format(field=field, cast=field_alias[0])
             if _len > 1:
-                return self._as.join(
-                    [field, self._qi(field_alias[1])]
-                )
+                return self._as.join([field, self._qi(field_alias[1])])
             else:
                 return field
         else:
@@ -143,13 +138,11 @@ class SqlDialect:
             database_name = self._qi(database_name)
         else:
             # database_name is actually a Literal expression, just add parenthesis
-            database_name = "({database})".format(database=database_name)
+            database_name = f"({database_name})"
 
         if alias is None:
             return database_name
-        return self._as.join(
-            [database_name, self._qi(alias)]
-        )
+        return self._as.join([database_name, self._qi(alias)])
 
     def _json_field_expr(self, field):
         """
@@ -194,7 +187,7 @@ class SqlDialect:
             and not path.startswith("'")
             and not path.startswith('"')
         ):
-            path = "'{}'".format(path)
+            path = f"'{path}'"
 
         expr = self._json_extract.format(field=field_expr, path=path)
 
@@ -226,7 +219,7 @@ class SqlDialect:
             and not path.startswith("'")
             and not path.startswith('"')
         ):
-            path = "'{}'".format(path)
+            path = f"'{path}'"
 
         expr = self._json_extract_text.format(field=field_expr, path=path)
 
@@ -283,7 +276,7 @@ class SqlDialect:
             and not path.startswith("'")
             and not path.startswith('"')
         ):
-            path = "'{}'".format(path)
+            path = f"'{path}'"
 
         expr = self._json_contains_path.format(field=field_expr, path=path)
 
@@ -351,9 +344,7 @@ class PgSqlDialect(SqlDialect):
         if table is not None:
             table = self._qi(table) + self._separator
             if schema is not None:
-                table = (
-                    self._qi(schema) + self._separator + table
-                )
+                table = self._qi(schema) + self._separator + table
         else:
             table = ""
 
@@ -375,9 +366,7 @@ class PgSqlDialect(SqlDialect):
             # generate pg-style cast with ::<type>
             cast = self._cast + field_alias[0]
             if _len > 1:
-                return self._as.join(
-                    [field + cast, self._qi(field_alias[1])]
-                )
+                return self._as.join([field + cast, self._qi(field_alias[1])])
             else:
                 return field + cast
         else:
@@ -397,7 +386,7 @@ class PgSqlDialect(SqlDialect):
             if path.startswith("$."):
                 path = path[2:]
             path = path.strip("'\"")
-            return "'{}'".format(path)
+            return f"'{path}'"
         return str(path)
 
     def json_extract(self, field, path, alias=None):
@@ -490,9 +479,9 @@ class PgSqlDialect(SqlDialect):
         field_expr = self._json_field_expr(field)
 
         if not path.startswith("'"):
-            path = "'{}'".format(path)
+            path = f"'{path}'"
 
-        expr = "{}::jsonb @? {}".format(field_expr, path)
+        expr = f"{field_expr}::jsonb @? {path}"
 
         if alias:
             return self._as.join([expr, self._qi(alias)])
@@ -514,6 +503,7 @@ class MySqlSqlDialect(SqlDialect):
         # Override only _json_extract_text for unquoted text extraction
         self._json_extract_text = "JSON_UNQUOTE(JSON_EXTRACT({field}, {path}))"
 
+    @lru_cache(maxsize=256)
     def _qi(self, identifier):
         """
         Quote a SQL identifier with backticks, escaping embedded backticks by doubling.
@@ -521,8 +511,8 @@ class MySqlSqlDialect(SqlDialect):
         :param identifier: identifier name (table, field, schema, database)
         :return: quoted identifier string, e.g. `my_table`
         """
-        escaped = identifier.replace('`', '``')
-        return '`{}`'.format(escaped)
+        escaped = identifier.replace("`", "``")
+        return f"`{escaped}`"
 
 
 class ClickHouseSqlDialect(SqlDialect):
@@ -557,7 +547,7 @@ class ClickHouseSqlDialect(SqlDialect):
             if path.startswith("$."):
                 path = path[2:]
             path = path.strip("'\"")
-            return "'{}'".format(path)
+            return f"'{path}'"
         return str(path)
 
     def json_extract(self, field, path, alias=None):

--- a/rick_db/sql/insert.py
+++ b/rick_db/sql/insert.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 from inspect import isclass
 from typing import Union
 
@@ -144,9 +144,9 @@ class Insert(SqlStatement):
             fields.append(self._dialect.field(name))
             placeholders.append(self._dialect.placeholder)
 
-        parts.append("({})".format(", ".join(fields)))
+        parts.append(f"({', '.join(fields)})")
         parts.append(Sql.SQL_VALUES)
-        parts.append("({})".format(", ".join(placeholders)))
+        parts.append(f"({', '.join(placeholders)})")
 
         # optional returning clause
         if self._returning:

--- a/rick_db/sql/select.py
+++ b/rick_db/sql/select.py
@@ -4,7 +4,7 @@
 # The Select() implementation is heavily inspired from the Zend_Db_Select approach. You can check the
 # Zend_Db_Select code and licensing at https://github.com/zendframework/zf1/blob/master/library/Zend/Db/Select.php
 
-import collections
+import collections.abc
 from typing import Union
 
 from .common import SqlStatement, Sql, Literal, SqlError, JsonField, PgJsonField
@@ -28,18 +28,20 @@ class Select(SqlStatement):
     WHERE_CLOSE = 3
 
     # validation rules
-    _valid_joins = [
-        Sql.INNER_JOIN,
-        Sql.LEFT_JOIN,
-        Sql.RIGHT_JOIN,
-        Sql.FULL_JOIN,
-        Sql.CROSS_JOIN,
-        Sql.NATURAL_JOIN,
-        Sql.INNER_JOIN_LATERAL,
-        Sql.LEFT_JOIN_LATERAL,
-    ]
-    _valid_unions = [Sql.SQL_UNION, Sql.SQL_UNION_ALL]
-    _valid_order = [Sql.SQL_ASC, Sql.SQL_DESC]
+    _valid_joins = frozenset(
+        {
+            Sql.INNER_JOIN,
+            Sql.LEFT_JOIN,
+            Sql.RIGHT_JOIN,
+            Sql.FULL_JOIN,
+            Sql.CROSS_JOIN,
+            Sql.NATURAL_JOIN,
+            Sql.INNER_JOIN_LATERAL,
+            Sql.LEFT_JOIN_LATERAL,
+        }
+    )
+    _valid_unions = frozenset({Sql.SQL_UNION, Sql.SQL_UNION_ALL})
+    _valid_order = frozenset({Sql.SQL_ASC, Sql.SQL_DESC})
 
     def __init__(self, dialect: SqlDialect = None):
         """
@@ -115,8 +117,8 @@ class Select(SqlStatement):
             .expr({Literal("NEXTVAL('some_sequence_name')": "seq_next") # select NEXTVAL('some_sequence_name') AS "seq_next"
         """
         if not isinstance(cols, collections.abc.Mapping):
-            if type(cols) in [list, tuple]:
-                cols = dict((col, None) for col in cols)
+            if isinstance(cols, (list, tuple)):
+                cols = {col: None for col in cols}
             else:
                 cols = {str(cols): None}
 
@@ -163,7 +165,7 @@ class Select(SqlStatement):
             .from(class_or_object, ["field1"])           # SELECT "field1" FROM "<object_table_name>"
             .from({class_or_object: "bar"}, ["field1"])  # SELECT "bar"."field1" FROM "<object_table_name>" AS "bar"
         """
-        if cols is None or (type(cols) in (list, tuple) and len(cols) == 0):
+        if cols is None or (isinstance(cols, (list, tuple)) and len(cols) == 0):
             cols = Sql.SQL_WILDCARD
 
         return self._join(Sql.FROM, table, None, None, None, None, cols, schema, None)
@@ -179,7 +181,7 @@ class Select(SqlStatement):
         Example:
             .lateral(Select().from_("users"), "u")  # SELECT
         """
-        if cols is None or (type(cols) in (list, tuple) and len(cols) == 0):
+        if cols is None or (isinstance(cols, (list, tuple)) and len(cols) == 0):
             cols = Sql.SQL_WILDCARD
         return self._join(
             Sql.LATERAL, {subquery: alias}, None, None, None, None, cols, None, None
@@ -240,8 +242,8 @@ class Select(SqlStatement):
             .order("id")                            # ORDER BY id ASC
             .order(["id", "a"], Select.ORDER_DESC)  # ORDER BY id DESC, a DESC
         """
-        ftype = type(fields)
-        if ftype not in (list, tuple, dict):
+        is_dict = isinstance(fields, dict)
+        if not isinstance(fields, (list, tuple, dict)):
             fields = [fields]
 
         if order is not None:
@@ -250,7 +252,7 @@ class Select(SqlStatement):
         else:
             order = ""
 
-        if ftype is dict:
+        if is_dict:
             for v in fields.values():
                 if v.upper() not in self._valid_order:
                     raise SqlError("order(): Invalid order direction: %s" % v)
@@ -391,7 +393,7 @@ class Select(SqlStatement):
             .group(Literal('SUM(field)'))       # GROUP BY SUM(field)
             .group(['field1', 'field2'])        # GROUP BY "field1", "field2"
         """
-        if type(fields) not in [list, tuple]:
+        if not isinstance(fields, (list, tuple)):
             fields = [fields]
 
         for field in fields:
@@ -432,7 +434,7 @@ class Select(SqlStatement):
             # field is actually a mapping table:field
             if len(field) != 1:
                 raise SqlError("having(): field collection must have exactly 1 record")
-            table, field = list(field.items()).pop()
+            table, field = next(iter(field.items()))
 
         if table is not None:
             if not isinstance(table, str):
@@ -455,19 +457,15 @@ class Select(SqlStatement):
 
         if value is None:
             if operator is None:
-                expression = "{fld}".format(fld=field)
+                expression = field
             else:
-                expression = "{fld} {op}".format(fld=field, op=operator)
+                expression = f"{field} {operator}"
             self._parts_having.append(expression)
         else:
             if operator is None:
-                expression = "{fld} {ph}".format(
-                    fld=field, ph=self._dialect.placeholder
-                )
+                expression = f"{field} {self._dialect.placeholder}"
             else:
-                expression = "{fld} {op} {ph}".format(
-                    fld=field, op=operator, ph=self._dialect.placeholder
-                )
+                expression = f"{field} {operator} {self._dialect.placeholder}"
             self._parts_having.append(expression)
             self._query_values[Sql.HAVING].append(value)
         return self
@@ -897,7 +895,7 @@ class Select(SqlStatement):
             # field is actually a mapping table:field
             if len(field) != 1:
                 raise SqlError("_where(): field collection must have exactly 1 record")
-            table, field = list(field.items()).pop()
+            table, field = next(iter(field.items()))
 
         if table is not None:
             if not isinstance(table, str):
@@ -919,54 +917,44 @@ class Select(SqlStatement):
 
         if value is None:
             if operator is None:
-                expression = "{fld}".format(fld=field)
+                expression = field
             else:
-                expression = "{fld} {op}".format(fld=field, op=operator)
+                expression = f"{field} {operator}"
             self._parts_where.append([expression, concat_with])
         else:
             if operator is None:
-                expression = "{fld} {ph}".format(
-                    fld=field, ph=self._dialect.placeholder
-                )
+                expression = f"{field} {self._dialect.placeholder}"
             else:
-                if isinstance(value, (list, tuple)) and operator is not None and operator.lower() in ("in", "not in"):
+                if (
+                    isinstance(value, (list, tuple))
+                    and operator is not None
+                    and operator.lower() in ("in", "not in")
+                ):
                     if len(value) == 0:
                         raise SqlError("_where(): empty list for IN clause")
                     placeholders = ", ".join([self._dialect.placeholder] * len(value))
-                    expression = "{fld} {op} ({phs})".format(
-                        fld=field, op=operator.upper(), phs=placeholders
-                    )
-                    for v in value:
-                        self._query_values[Sql.WHERE].append(v)
+                    expression = f"{field} {operator.upper()} ({placeholders})"
+                    self._query_values[Sql.WHERE].extend(value)
                     value = None
                 elif isinstance(value, Select):
                     sql, value = value.assemble()
-                    expression = "{fld} {op} ({query})".format(
-                        fld=field, op=operator, query=sql
-                    )
-                    for v in value:
-                        self._query_values[Sql.WHERE].append(v)
+                    expression = f"{field} {operator} ({sql})"
+                    self._query_values[Sql.WHERE].extend(value)
                     value = None
                 elif isinstance(value, collections.abc.Mapping):
                     if len(value) != 1:
                         raise SqlError(
                             "_where(): value collection must have exactly 1 record"
                         )
-                    tgt_tbl, tgt_field = list(value.items()).pop()
+                    tgt_tbl, tgt_field = next(iter(value.items()))
                     tmp_field_expr = self._dialect.field(tgt_field, None, tgt_tbl)
-                    expression = "{fld} {op} {to_fld}".format(
-                        fld=field, op=operator, to_fld=tmp_field_expr
-                    )
+                    expression = f"{field} {operator} {tmp_field_expr}"
                     value = None
                 elif isinstance(value, Literal):
-                    expression = "{fld} {op} {lit}".format(
-                        fld=field, op=operator, lit=str(value)
-                    )
+                    expression = f"{field} {operator} {value}"
                     value = None
                 else:
-                    expression = "{fld} {op} {ph}".format(
-                        fld=field, op=operator, ph=self._dialect.placeholder
-                    )
+                    expression = f"{field} {operator} {self._dialect.placeholder}"
             self._parts_where.append([expression, concat_with])
             if value is not None:
                 self._query_values[Sql.WHERE].append(value)
@@ -1008,7 +996,7 @@ class Select(SqlStatement):
 
         # join table
         join_table, alias, schema = self._parse_table_def(join_table, schema)
-        if alias in self._parts_from.keys():
+        if alias in self._parts_from:
             raise SqlError(f"_join(): duplicate alias for table {alias}")
 
         # join expression (if necessary)
@@ -1027,7 +1015,7 @@ class Select(SqlStatement):
                     raise SqlError(
                         "_join(): atmost one name:alias mapping per call is required"
                     )
-                from_table, expr_alias = list(from_table.items()).pop()
+                from_table, expr_alias = next(iter(from_table.items()))
                 if not isinstance(expr_alias, str):
                     raise SqlError("_join(): invalid alias type")
 
@@ -1049,7 +1037,7 @@ class Select(SqlStatement):
 
             if expr_alias is None:
                 expr_alias = from_table
-            if expr_alias not in self._parts_from.keys():
+            if expr_alias not in self._parts_from:
                 raise SqlError("_join(): table {} not found".format(expr_alias))
 
             if operator is None:
@@ -1097,7 +1085,7 @@ class Select(SqlStatement):
                 raise SqlError(
                     "_join(): atmost one name:alias mapping per call is required"
                 )
-            table, alias = list(table.items()).pop()
+            table, alias = next(iter(table.items()))
             if not isinstance(alias, str):
                 raise SqlError("_join(): invalid alias type")
 
@@ -1144,8 +1132,8 @@ class Select(SqlStatement):
         """
         i = 2
         alias = name
-        while alias in self._parts_from.keys():
-            alias = "_".join([name, str(i)])
+        while alias in self._parts_from:
+            alias = f"{name}_{i}"
             i += 1
         return alias
 
@@ -1157,7 +1145,7 @@ class Select(SqlStatement):
         :param alias: str, table alias
         :return: self
         """
-        if table_name in self._parts_columns.keys():
+        if table_name in self._parts_columns:
             if table_name == Sql.ANONYMOUS:
                 raise SqlError("Columns for anonymous expression table already exist")
             raise SqlError("Columns for table %s already exist" % table_name)
@@ -1213,75 +1201,50 @@ class Select(SqlStatement):
         :return: string
         """
         parts = [Sql.SQL_FROM]
-        from_parts = {}
-        join_parts = {}
-        lateral_parts = {}
+        from_names = []
+        join_stmts = []
+
         for alias, details in self._parts_from.items():
-            if details["joinType"] == Sql.FROM:
-                from_parts[alias] = details
-            elif details["joinType"] == Sql.LATERAL:
-                lateral_parts[alias] = details
-            else:
-                join_parts[alias] = details
+            join_type = details["joinType"]
+            tbl_alias = alias if alias != details["tableName"] else None
 
-        # FROM clause
-        names = []
-        for alias, details in from_parts.items():
-            tbl_alias = None
-            if alias != details["tableName"]:
-                tbl_alias = alias
-            names.append(
-                self._dialect.table(details["tableName"], tbl_alias, details["schema"])
-            )
-
-        # LATERAL clause
-        if len(lateral_parts) > 0:
-            for alias, details in lateral_parts.items():
-                tbl_alias = None
-                if alias != details["tableName"]:
-                    tbl_alias = alias
-                names.append(
-                    " ".join(
-                        [
-                            Sql.SQL_LATERAL,
-                            self._dialect.table(details["tableName"], tbl_alias),
-                        ]
+            if join_type == Sql.FROM:
+                from_names.append(
+                    self._dialect.table(
+                        details["tableName"], tbl_alias, details["schema"]
                     )
                 )
+            elif join_type == Sql.LATERAL:
+                from_names.append(
+                    f"{Sql.SQL_LATERAL} {self._dialect.table(details['tableName'], tbl_alias)}"
+                )
+            else:
+                stmt = [
+                    join_type,
+                    self._dialect.table(
+                        details["tableName"], tbl_alias, details["schema"]
+                    ),
+                ]
+
+                if details["joinCondition"] is not None:
+                    stmt.append(Sql.SQL_ON)
+                    cond = details["joinCondition"]
+                    if isinstance(cond, Literal):
+                        stmt.append(f"({cond})")
+                    else:
+                        stmt.append(cond)
+
+                join_stmts.append(" ".join(stmt))
 
         # build FROM, LATERAL
-        parts.append(", ".join(names))
+        parts.append(", ".join(from_names))
 
         # JOIN clauses
-        names = []
-        for alias, details in join_parts.items():
-            stmt = []
-            tbl_alias = None
-            stmt.append(details["joinType"])
-            if alias != details["tableName"]:
-                tbl_alias = alias
-            stmt.append(
-                self._dialect.table(details["tableName"], tbl_alias, details["schema"])
-            )
-
-            if details["joinCondition"] is not None:
-                stmt.append(Sql.SQL_ON)
-                stmt.append(details["joinCondition"])
-
-            # convert possible literals to self-contained clauses
-            _stmt = []
-            for s in stmt:
-                if isinstance(s, Literal):
-                    _stmt.append("({})".format(str(s)))
-                else:
-                    _stmt.append(s)
-            names.append(" ".join(_stmt))  # complete join statement
-        if len(names) > 0:
-            parts.append(" ".join(names))  # combine all join statements
+        if join_stmts:
+            parts.append(" ".join(join_stmts))
 
         # copy values that may have been passed by subqueries in joins
-        for v in self._query_values[Sql.JOIN]:
-            self._values.append(v)
+        self._values.extend(self._query_values[Sql.JOIN])
 
         return " ".join(parts)
 
@@ -1353,11 +1316,14 @@ class Select(SqlStatement):
                     parts.append(" ".join(stmt))
             elif isinstance(expr, (list, tuple)):
                 for field in expr:
-                    parts.append(" ".join([self._dialect.field(field), order]))
+                    rendered = self._dialect.field(field)
+                    parts.append(f"{rendered} {order}" if order else rendered)
             elif isinstance(expr, Literal):
-                parts.append(" ".join([str(expr), order]))
+                rendered = str(expr)
+                parts.append(f"{rendered} {order}" if order else rendered)
             elif isinstance(expr, str):
-                parts.append(" ".join([self._dialect.field(expr), order]))
+                rendered = self._dialect.field(expr)
+                parts.append(f"{rendered} {order}" if order else rendered)
             else:
                 raise SqlError("order(): invalid field type: %s" % str(type(expr)))
 
@@ -1399,8 +1365,7 @@ class Select(SqlStatement):
                 i += 1
 
         # copy values so they match the rendering sequence
-        for v in self._query_values[Sql.WHERE]:
-            self._values.append(v)
+        self._values.extend(self._query_values[Sql.WHERE])
 
         return " ".join(parts)
 
@@ -1433,8 +1398,7 @@ class Select(SqlStatement):
             )
             parts.append(clause)
 
-        for v in self._query_values[Sql.HAVING]:
-            self._values.append(v)
+        self._values.extend(self._query_values[Sql.HAVING])
 
         glue = " " + Sql.SQL_AND + " "
         return " ".join([Sql.SQL_HAVING, glue.join(parts)])
@@ -1489,7 +1453,7 @@ class Select(SqlStatement):
             if isinstance(v, Literal):
                 self._values[k] = str(v)
 
-        return " ".join(parts).strip(), self._values
+        return " ".join(p for p in parts if p), self._values
 
     def dialect(self) -> SqlDialect:
         """

--- a/rick_db/sql/update.py
+++ b/rick_db/sql/update.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 from inspect import isclass
 from typing import Union
 
@@ -150,39 +150,36 @@ class Update(SqlStatement):
 
         if value is None:
             if operator is None:
-                expression = "{fld}".format(fld=field)
+                expression = field
             else:
-                expression = "{fld} {op}".format(fld=field, op=operator)
+                expression = f"{field} {operator}"
             self._clauses.append([expression, concat])
         else:
             if isinstance(value, dict):
                 raise SqlError("_where(): invalid value type: %s" % str(type(value)))
 
             if operator is None:
-                expression = "{fld} {ph}".format(
-                    fld=field, ph=self._dialect.placeholder
-                )
+                expression = f"{field} {self._dialect.placeholder}"
             else:
-                if isinstance(value, (list, tuple)) and operator.lower() in ("in", "not in"):
+                if isinstance(value, (list, tuple)) and operator.lower() in (
+                    "in",
+                    "not in",
+                ):
                     if len(value) == 0:
                         raise SqlError("_where(): empty list for IN clause")
                     placeholders = ", ".join([self._dialect.placeholder] * len(value))
-                    expression = "{fld} {op} ({phs})".format(
-                        fld=field, op=operator.upper(), phs=placeholders
-                    )
+                    expression = f"{field} {operator.upper()} ({placeholders})"
                     self._clause_values.extend(value)
                     value = None
                 elif isinstance(value, (list, tuple)):
-                    raise SqlError("_where(): invalid value type: %s" % str(type(value)))
+                    raise SqlError(
+                        "_where(): invalid value type: %s" % str(type(value))
+                    )
                 elif isinstance(value, Select):
                     sql, value = value.assemble()
-                    expression = "{fld} {op} ({query})".format(
-                        fld=field, op=operator, query=sql
-                    )
+                    expression = f"{field} {operator} ({sql})"
                 else:
-                    expression = "{fld} {op} {ph}".format(
-                        fld=field, op=operator, ph=self._dialect.placeholder
-                    )
+                    expression = f"{field} {operator} {self._dialect.placeholder}"
 
             self._clauses.append([expression, concat])
             if value is not None:
@@ -233,18 +230,17 @@ class Update(SqlStatement):
         # generate field list and placeholder list
         fields = []
         values = []
-        expression = "{}={}"
         for i in range(0, lf):
             name = self._dialect.field(self._fields[i])
             value = self._values[i]
             if isinstance(value, Literal):
-                fields.append(expression.format(name, str(value)))
+                fields.append(f"{name}={value}")
             elif isinstance(value, Select):
                 value, sql_values = value.assemble()
                 values.extend(sql_values)
-                fields.append(expression.format(name, value))
+                fields.append(f"{name}={value}")
             else:
-                fields.append(expression.format(name, self._dialect.placeholder))
+                fields.append(f"{name}={self._dialect.placeholder}")
                 values.append(value)
 
         parts.append(", ".join(fields))
@@ -266,9 +262,7 @@ class Update(SqlStatement):
         if len(self._returning) > 0:
             parts.append(Sql.SQL_RETURNING)
 
-            fields = []
-            for name in self._returning:
-                fields.append("{field}".format(field=self._dialect.field(name)))
+            fields = [self._dialect.field(name) for name in self._returning]
             parts.append(", ".join(fields))
 
         return " ".join(parts), values


### PR DESCRIPTION
Cache identifier quoting with lru_cache, replace .format() with f-strings, fix list(dict.items()).pop() anti-pattern, remove unnecessary .keys() calls, single-pass _render_from(), and use frozenset for validation lookups.

## Summary by Sourcery

Improve SQL query building and record mapping performance through caching, faster container operations, and streamlined clause rendering.

Enhancements:
- Use frozenset-based validation sets and isinstance checks in Select for faster and clearer type and membership handling.
- Refactor FROM/JOIN rendering into a single-pass _render_from implementation and simplify ORDER/HAVING/WHERE assembly, including filtered part joining in assemble().
- Cache SQL identifier quoting in SQL dialects and introduce a cached COUNT(*) Literal in Fn to avoid repeated object and string creation.
- Replace multiple append loops with list.extend, avoid unnecessary dict.keys() calls, and simplify BaseRecord accessors and asrecord construction for more efficient record handling.
- Adopt f-strings across SQL builders and dialects for more efficient and readable SQL string construction.

Documentation:
- Document performance-related changes in the CHANGELOG under version 2.2.1.