### PR TITLE
Bump version to 2.2.3, add ClickHouseConnectionPool and fix audit issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## [2.2.3]
+
+### Added
+- `ClickHouseConnectionPool` — thread-safe connection pool for ClickHouse, with configurable `minconn`/`maxconn`, connection health checks via `ping`, stale connection recovery, custom connection factory support, and profiler passthrough
+- `ClickHouseManager` now accepts both `ClickHouseConnection` and `ClickHouseConnectionPool`, with optional `database` parameter override
+- Integration and concurrency tests for `ClickHouseConnectionPool`
+- Pool-based `ClickHouseManager` integration tests
+
+### Changed
+- Fixed ClickHouse docker image tag in `tox.ini` from non-existent `25.8` to `25.6`
+- **Breaking:** ClickHouse migrations no longer support multiple SQL statements per file. The previous semicolon-based splitting was unreliable (broke on semicolons inside string literals). Each migration file must now contain a single SQL statement.
+
+### Bug Fixes
+
+#### Critical
+- **profiler/profilers.py**: `NullProfiler.get_events()` now returns an empty `EventCollection` instead of `None`, preventing `TypeError` when iterating over profiler events on unprofiled connections
+- **migrations.py**: `BaseMigrationManager.repository` property now caches the repository instance instead of creating a new one on every access, eliminating redundant object creation and enabling query cache reuse
+- **sqlite/migrations.py**: Replaced naive `content.split(";")` with a string-aware statement splitter that respects single-quoted strings, preventing breakage on SQL containing semicolons in string literals
+
+#### High
+- **connection.py**: Replaced mutable default argument `profiler=NullProfiler()` with `None` sentinel pattern to avoid sharing a single profiler instance across all connections
+- **repository.py**: Fixed `type() not in [list, tuple]` checks to use `isinstance()` in `update_where()` and `count_where()` for proper subclass support
+- **repository.py**: Removed redundant `.keys()` call from `self.pk in data.keys()` in `update()`
+- **mapper.py**: `BaseRecord.add()` now copies `_fieldmap` on first write to avoid mutating the class-level dict shared across all instances
+- **profiler/profilers.py**: `DefaultProfiler` is now thread-safe — `add_event()`, `clear()`, and `get_events()` are protected by a lock; `get_events()` returns a snapshot copy
+
+#### Medium
+- **cache.py**: Removed redundant `.keys()` calls in `QueryCache.get()` and `has()`
+- **dbgrid.py**: Removed redundant `.keys()` call in search type validation
+- **insert.py**: `Insert.values()` now stores `list(values.keys())` instead of a `dict_keys` view that could change if the source dict is mutated
+- **cli/config.py**: `type(config[k]) is dict` replaced with `isinstance()` for compatibility with dict subclasses from TOML parsers
+- **cli/config.py**: Password file reader now strips trailing newline/carriage return to prevent authentication failures
+- **cli/manage.py**: Replaced `p.name.rsplit(".py")[0]` with `p.stem` to correctly extract module names from filenames containing `.py` elsewhere
+- **select.py**: Removed redundant `operator is not None` check inside the `else` branch of `_where()` where `operator` is guaranteed non-None
+- **select.py**: Changed `str(cols) == "*"` wildcard check to `cols == "*"` to avoid false negatives when `cols` is a list
+
+#### Low
+- **mapper.py**: `type(data) is not dict` replaced with `not isinstance(data, dict)` in `__setattr__` for proper dict subclass handling
+- **sql/common.py**: `JsonField.__getitem__` now uses dialect-aware JSON extraction instead of hardcoded PostgreSQL `->>`  operator; falls back to `JSON_EXTRACT()` without a dialect
+- **cli/commands/dto.py**: Generated class names are now sanitized — non-alphanumeric characters are stripped and names starting with digits are prefixed with `T`
+- **pool.py**: Fixed race condition in stale connection recovery where releasing the `_used` slot before creating the replacement could allow another thread to exceed `maxconn`
+- **clickhouse/repository.py**: Fixed `type() not in [list, tuple]` checks to use `isinstance()`; removed redundant `.keys()` call
+- **clickhouse_example.py**: Fixed `f.field_type` reference to `f.type` (attribute does not exist on `FieldRecord`)
+
 ## [2.2.2]
 
 ### Performance

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,9 +68,11 @@ conn = Sqlite3Connection("mydb.db")       # file-based
 conn = Sqlite3Connection(":memory:")       # in-memory
 
 # ClickHouse
-from rick_db.backend.clickhouse import ClickHouseConnection
+from rick_db.backend.clickhouse import ClickHouseConnection, ClickHouseConnectionPool
 
 conn = ClickHouseConnection(host="localhost", port=8123, database="mydb")
+# or with pooling (recommended for production)
+pool = ClickHouseConnectionPool(host="localhost", port=8123, database="mydb")
 ```
 
 ### Use the Repository
@@ -618,10 +620,11 @@ from rick_db.backend.sqlite import Sqlite3Manager
 mgr = Sqlite3Manager(conn)
 mgr.tables(), mgr.views(), mgr.table_fields("users"), mgr.table_pk("users")
 
-# ClickHouse
+# ClickHouse (accepts connection or pool)
 from rick_db.backend.clickhouse import ClickHouseManager
 
 mgr = ClickHouseManager(conn)
+mgr = ClickHouseManager(pool)  # also works with ClickHouseConnectionPool
 mgr.tables(), mgr.views(), mgr.table_fields("users"), mgr.table_pk("users")
 mgr.databases(), mgr.users()
 ```
@@ -660,5 +663,5 @@ tox -e flake
 - `DbConnectionError` is the correct name; `ConnectionError` alias exists for backward compatibility
 - SQLite has no `ILIKE`; DbGrid uses `UPPER()` for case-insensitive search
 - Migration `execute()` is not fully transactional between SQL execution and registration
-- `DefaultProfiler` is not thread-safe
+- `DefaultProfiler` is thread-safe (protected by lock); `get_events()` returns a snapshot copy
 - Supports Python 3.9+

--- a/docs/classes/clickhouse_sql.md
+++ b/docs/classes/clickhouse_sql.md
@@ -61,7 +61,11 @@ SQL builders.
 
 ```python
 from rick_db import fieldmapper
-from rick_db.backend.clickhouse import ClickHouseConnection, ClickHouseRepository
+from rick_db.backend.clickhouse import (
+    ClickHouseConnection,
+    ClickHouseConnectionPool,
+    ClickHouseRepository,
+)
 
 @fieldmapper(tablename="events", pk="id")
 class Event:
@@ -69,8 +73,15 @@ class Event:
     event_type = "event_type"
     amount = "amount"
 
+# With a direct connection
 conn = ClickHouseConnection(host="localhost", port=8123, database="mydb")
 repo = ClickHouseRepository(conn, Event)
+
+# With a connection pool (recommended for production)
+pool = ClickHouseConnectionPool(host="localhost", port=8123, database="mydb")
+with pool.connection() as conn:
+    repo = ClickHouseRepository(conn, Event)
+    events = repo.fetch_all()
 ```
 
 ### Overridden methods

--- a/docs/classes/clickhousemanager.md
+++ b/docs/classes/clickhousemanager.md
@@ -4,16 +4,29 @@ This class extends [ManagerInterface](managerinterface.md) to provide a specific
 It uses ClickHouse `system.*` tables for introspection. The `schema` parameter maps to ClickHouse `database`;
 when `None`, the connection's current database is used.
 
-```python
-from rick_db.backend.clickhouse import ClickHouseConnection, ClickHouseManager
+Accepts either a `ClickHouseConnection` or a `ClickHouseConnectionPool`.
 
+```python
+from rick_db.backend.clickhouse import ClickHouseConnection, ClickHouseConnectionPool, ClickHouseManager
+
+# With a connection
 conn = ClickHouseConnection(host="localhost", port=8123, database="mydb")
 mgr = ClickHouseManager(conn)
+
+# With a connection pool (recommended for production)
+pool = ClickHouseConnectionPool(host="localhost", port=8123, database="mydb")
+mgr = ClickHouseManager(pool)
+
+# With explicit database name
+mgr = ClickHouseManager(pool, database="other_db")
 ```
 
-### ClickHouseManager.**\_\_init\_\_(db)**
+### ClickHouseManager.**\_\_init\_\_(db, database=None)**
 
-Creates a new ClickHouseManager instance. Accepts a `ClickHouseConnection`.
+Creates a new ClickHouseManager instance.
+
+- `db` — a `ClickHouseConnection` or `ClickHouseConnectionPool`
+- `database` — optional database name override. If not provided, the database is extracted from the connection's client config or the pool's connection parameters.
 
 ### Supported methods
 
@@ -59,7 +72,10 @@ In ClickHouse, databases serve the role of schemas. The following methods delega
 
 The following methods are **not supported** and will raise `NotImplementedError`:
 
-- `user_groups()`
-- `create_schema()`
-- `drop_schema()`
+- `create_schema()` — use `create_database()` instead
+- `drop_schema()` — use `drop_database()` instead
 - `kill_clients()`
+
+The following method returns an empty result (ClickHouse has no group concept):
+
+- `user_groups()` — returns `[]`

--- a/docs/classes/profiler.md
+++ b/docs/classes/profiler.md
@@ -44,8 +44,13 @@ Return internal profiling event collection.
 ## Class rick_db.profiler.**NullProfiler**
 
 A [ProfilerInterface](#class-rick_dbprofilerprofilerinterface)-based class with dummy behaviour, to be used when no profiler is desired.
+All methods are no-ops. `get_events()` returns a fresh empty [EventCollection](#class-rick_dbprofilereventcollection) on each call.
 
 
 ## Class rick_db.profiler.**DefaultProfiler**
 
 A [ProfilerInterface](#class-rick_dbprofilerprofilerinterface)-based class. Events are kept in-memory.
+
+Thread-safe: all methods are protected by a lock, making it safe to share a single `DefaultProfiler` instance
+across multiple connections (e.g. via a connection pool). `get_events()` returns a snapshot copy of the internal
+collection, so iterating over events is not affected by concurrent `add_event()` calls.

--- a/docs/connection.md
+++ b/docs/connection.md
@@ -96,19 +96,25 @@ ClickHouse is supported via the `clickhouse-connect` HTTP client. Install the op
 $ pip install clickhouse-connect
 ```
 
+There are two ClickHouse connectors available - a simple connector and a thread-safe connection pool; the recommended
+usage is to use **ClickHouseConnectionPool**.
+
 Available connection parameters:
 
-|Field| Description |
-|---|---|
-|host| ClickHouse server hostname (defaults to "localhost") |
-|port| HTTP port (defaults to 8123) |
-|username| User name used to authenticate (defaults to "default") |
-|password| Password used to authenticate (defaults to empty) |
-|database| Database name (defaults to "default") |
+|Field| Connector | Description |
+|---|---|---|
+|host| All | ClickHouse server hostname (defaults to "localhost") |
+|port| All | HTTP port (defaults to 8123) |
+|username| All | User name used to authenticate (defaults to "default") |
+|password| All | Password used to authenticate (defaults to empty) |
+|database| All | Database name (defaults to "default") |
+|minconn| ClickHouseConnectionPool | Minimum number of connections to keep, defaults to 5 if not provided |
+|maxconn| ClickHouseConnectionPool | Maximum number of connections to keep, defaults to 25 if not provided |
+|ping| ClickHouseConnectionPool | If true (default), connections are validated before use |
 
 Any additional keyword arguments are passed directly to `clickhouse_connect.get_client()`.
 
-Example:
+Using ClickHouseConnection:
 ```python
 from rick_db.backend.clickhouse import ClickHouseConnection
 
@@ -125,6 +131,27 @@ conn = ClickHouseConnection(**config)
 with conn.cursor() as c:
     # do stuff
     pass
+```
+
+Using ClickHouseConnectionPool:
+```python
+from rick_db.backend.clickhouse import ClickHouseConnectionPool
+
+config = {
+    'host': 'localhost',
+    'port': 8123,
+    'username': 'default',
+    'password': '',
+    'database': 'my_database',
+    'minconn': 4,
+}
+
+# create connection pool
+pool = ClickHouseConnectionPool(**config)
+with pool.connection() as conn:     # fetch a connection from the pool
+    with conn.cursor() as c:        # create a cursor
+        # do stuff
+        pass
 ```
 
 > Note: ClickHouse has no real transactions. `commit()` and `rollback()` are no-ops. The `Repository.transaction()`
@@ -190,3 +217,22 @@ with pool.connection() as conn:
 for evt in pool.profiler.get_events():
     print(evt.query, evt.elapsed)
 ```
+
+Example using ClickHouseConnectionPool:
+```python
+from rick_db.backend.clickhouse import ClickHouseConnectionPool
+from rick_db.profiler import DefaultProfiler
+
+pool = ClickHouseConnectionPool(host="localhost", port=8123, database="mydb")
+pool.profiler = DefaultProfiler()
+
+with pool.connection() as conn:
+    with conn.cursor() as c:
+        c.exec("SELECT 1")
+
+for evt in pool.profiler.get_events():
+    print(evt.query, evt.elapsed)
+```
+
+> Note: The profiler instance is captured at connection checkout time. Reassigning `pool.profiler`
+> after connections are already checked out will not affect those existing connections.

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,8 +32,9 @@ and a Repository pattern implementation.
   configurable patterns), exact-match filtering, multi-field sorting, and returns both total count and paginated results.
 
 - **[Connections](connection.md)** — high-level connectors for **PostgreSQL** (psycopg2, with thread-safe
-  connection pooling), **SQLite3** (stdlib), and **ClickHouse** (clickhouse-connect). All connectors share a common
-  interface with cursor management, transaction support, and pluggable query profiling.
+  connection pooling), **SQLite3** (stdlib), and **ClickHouse** (clickhouse-connect, with thread-safe
+  connection pooling). All connectors share a common interface with cursor management, transaction support,
+  and pluggable query profiling.
 
 - **[SQL Dialects](classes/sqldialect.md)** — dialect objects handle database-specific differences (placeholder syntax,
   identifier quoting, type casting, JSON operators). Available for PostgreSQL, SQLite, ClickHouse, and

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -248,6 +248,7 @@ Migrations can also be managed programmatically. Each backend provides a Manager
 |---------|---------|-----------------|
 | PostgreSQL | `PgManager` | `PgMigrationManager` |
 | SQLite | `Sqlite3Manager` | `Sqlite3MigrationManager` |
+| ClickHouse | `ClickHouseManager` | `ClickHouseMigrationManager` |
 
 ```python
 from rick_db.backend.sqlite import Sqlite3Connection, Sqlite3Manager, Sqlite3MigrationManager
@@ -282,5 +283,27 @@ mm.flatten(MigrationRecord(name="schema.sql"))
 ```
 
 For PostgreSQL, use `PgManager` and `PgMigrationManager` from `rick_db.backend.pg` with the same API.
+
+For ClickHouse:
+```python
+from rick_db.backend.clickhouse import ClickHouseConnection, ClickHouseManager, ClickHouseMigrationManager
+from rick_db.migrations import MigrationRecord
+
+conn = ClickHouseConnection(host="localhost", port=8123, database="mydb")
+mgr = ClickHouseManager(conn)
+mm = ClickHouseMigrationManager(mgr)
+```
+
+ClickHouseManager also accepts a `ClickHouseConnectionPool`:
+```python
+from rick_db.backend.clickhouse import ClickHouseConnectionPool, ClickHouseManager, ClickHouseMigrationManager
+
+pool = ClickHouseConnectionPool(host="localhost", port=8123, database="mydb")
+mgr = ClickHouseManager(pool)
+mm = ClickHouseMigrationManager(mgr)
+```
+
+> **Note:** ClickHouse migration files must contain a single SQL statement each. Multi-statement migrations
+> should be split into separate files.
 
 See [Examples](examples.md#migration-workflow) for a complete runnable example.

--- a/examples/clickhouse/clickhouse_example.py
+++ b/examples/clickhouse/clickhouse_example.py
@@ -2,8 +2,8 @@
 ClickHouse connection, repository, and introspection example.
 
 Demonstrates:
- - ClickHouseConnection setup
- - ClickHouseManager for schema introspection
+ - ClickHouseConnection and ClickHouseConnectionPool setup
+ - ClickHouseManager for schema introspection (with connection and pool)
  - Repository usage with ClickHouse
  - Query builder with ClickHouseSqlDialect
 
@@ -12,7 +12,12 @@ Requirements:
  - pip install clickhouse-connect
 """
 from rick_db import fieldmapper, Repository
-from rick_db.backend.clickhouse import ClickHouseConnection, ClickHouseManager
+from rick_db.backend.clickhouse import (
+    ClickHouseConnection,
+    ClickHouseConnectionPool,
+    ClickHouseManager,
+    ClickHouseRepository,
+)
 from rick_db.sql import Select, Fn
 
 
@@ -84,7 +89,7 @@ def introspect(conn):
     if mgr.table_exists("events"):
         print("\nFields in 'events':")
         for f in mgr.table_fields("events"):
-            print("  {} ({})".format(f.field, f.field_type))
+            print("  {} ({})".format(f.field, f.type))
 
         pk = mgr.table_pk("events")
         if pk:
@@ -159,6 +164,33 @@ def cleanup(conn):
         c.close()
 
 
+def pool_examples():
+    """Connection pool usage with ClickHouseConnectionPool."""
+    pool = ClickHouseConnectionPool(**db_cfg, minconn=2, maxconn=10)
+
+    print("\n=== Connection Pool ===")
+
+    # Manager works with pool directly
+    mgr = ClickHouseManager(pool)
+    print("Tables via pool:", mgr.tables())
+
+    # Repository via pool connection
+    with pool.connection() as conn:
+        repo = ClickHouseRepository(conn, Event)
+        events = repo.fetch_all()
+        print("Events via pool:", len(events))
+
+    # Multiple connections from pool
+    with pool.connection() as conn1:
+        with pool.connection() as conn2:
+            repo1 = ClickHouseRepository(conn1, Event)
+            repo2 = ClickHouseRepository(conn2, Event)
+            print("Conn1 count:", repo1.count())
+            print("Conn2 count:", repo2.count())
+
+    pool.close()
+
+
 def main():
     conn = ClickHouseConnection(**db_cfg)
 
@@ -167,6 +199,7 @@ def main():
         seed_data(conn)
         introspect(conn)
         query_examples(conn)
+        pool_examples()
     finally:
         cleanup(conn)
         conn.close()

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -323,3 +323,63 @@ class TestClickHouseExamples:
                 c.exec("DROP TABLE IF EXISTS test_example_events")
                 c.close()
             conn.close()
+
+    def test_clickhouse_pool(self):
+        """Test ClickHouseConnectionPool and ClickHouseManager with pool."""
+        from rick_db.backend.clickhouse import (
+            ClickHouseConnectionPool,
+            ClickHouseManager,
+            ClickHouseRepository,
+        )
+        from rick_db import fieldmapper
+
+        pool = ClickHouseConnectionPool(
+            host=os.environ.get("CLICKHOUSE_HOST", "localhost"),
+            port=int(os.environ.get("CLICKHOUSE_PORT", 18123)),
+            username=os.environ.get("CLICKHOUSE_USER", "some_user"),
+            password=os.environ.get("CLICKHOUSE_PASSWORD", "somePassword"),
+            database=os.environ.get("CLICKHOUSE_DB", "testdb"),
+            minconn=2,
+            maxconn=5,
+        )
+
+        try:
+            # Manager with pool
+            mgr = ClickHouseManager(pool)
+            dbs = mgr.databases()
+            assert isinstance(dbs, list)
+            assert len(dbs) > 0
+
+            # Create table, insert, query via pool
+            with pool.connection() as conn:
+                with conn.cursor() as c:
+                    c.exec(
+                        """
+                        CREATE TABLE IF NOT EXISTS test_pool_events (
+                            id UInt64,
+                            event_type String
+                        ) ENGINE = MergeTree()
+                        ORDER BY id
+                        """
+                    )
+                    c.exec(
+                        "INSERT INTO test_pool_events (id, event_type) VALUES (1, 'test')"
+                    )
+
+            @fieldmapper(tablename="test_pool_events", pk="id")
+            class PoolEvent:
+                id = "id"
+                event_type = "event_type"
+
+            with pool.connection() as conn:
+                repo = ClickHouseRepository(conn, PoolEvent)
+                events = repo.fetch_all()
+                assert len(events) == 1
+                assert events[0].event_type == "test"
+
+            assert mgr.table_exists("test_pool_events")
+            mgr.drop_table("test_pool_events")
+            assert mgr.table_exists("test_pool_events") is False
+
+        finally:
+            pool.close()

--- a/rick_db/backend/clickhouse/__init__.py
+++ b/rick_db/backend/clickhouse/__init__.py
@@ -1,4 +1,5 @@
 from .connection import ClickHouseConnection
+from .pool import ClickHouseConnectionPool
 from .manager import ClickHouseManager
 from .migrations import ClickHouseMigrationManager
 from .repository import ClickHouseRepository

--- a/rick_db/backend/clickhouse/manager.py
+++ b/rick_db/backend/clickhouse/manager.py
@@ -25,7 +25,7 @@ class ClickHouseManager(ManagerInterface):
                 self._database = database
             else:
                 self._database = db.client.database
-        else:
+        elif isinstance(db, PoolInterface):
             self._db = None
             self._pool = db
             self.dialect = db.dialect()
@@ -33,6 +33,10 @@ class ClickHouseManager(ManagerInterface):
                 self._database = database
             else:
                 self._database = db._kwargs.get("database", "default")
+        else:
+            raise TypeError(
+                f"db must be a Connection or PoolInterface, not {type(db).__name__}"
+            )
 
     @contextmanager
     def conn(self) -> Connection:

--- a/rick_db/backend/clickhouse/manager.py
+++ b/rick_db/backend/clickhouse/manager.py
@@ -1,7 +1,7 @@
 from contextlib import contextmanager
-from typing import Optional, List
+from typing import Optional, List, Union
 
-from rick_db import Connection
+from rick_db import Connection, PoolInterface
 from rick_db.manager import ManagerInterface, FieldRecord, UserRecord
 
 
@@ -12,20 +12,47 @@ class ClickHouseManager(ManagerInterface):
     Uses ClickHouse system.* tables for metadata queries.
     The schema parameter maps to ClickHouse database; when None,
     uses the connection's current database.
+
+    Accepts either a ClickHouseConnection or ClickHouseConnectionPool.
     """
 
-    def __init__(self, db):
-        self._db = db
-        self.dialect = db.dialect()
-        # extract current database from client config
-        self._database = db.client.database
+    def __init__(self, db: Union[Connection, PoolInterface], database: str = None):
+        if isinstance(db, Connection):
+            self._db = db
+            self._pool = None
+            self.dialect = db.dialect()
+            if database is not None:
+                self._database = database
+            else:
+                self._database = db.client.database
+        else:
+            self._db = None
+            self._pool = db
+            self.dialect = db.dialect()
+            if database is not None:
+                self._database = database
+            else:
+                self._database = db._kwargs.get("database", "default")
 
     @contextmanager
     def conn(self) -> Connection:
-        yield self._db
+        if self._db:
+            yield self._db
+        elif self._pool:
+            conn = None
+            try:
+                conn = self._pool.getconn()
+                yield conn
+            finally:
+                if conn is not None:
+                    self._pool.putconn(conn)
+        else:
+            raise RuntimeError("no database connection or pool available")
 
-    def backend(self):
-        return self._db
+    def backend(self) -> Union[Connection, PoolInterface]:
+        if self._db:
+            return self._db
+        return self._pool
 
     def tables(self, schema=None) -> List[str]:
         database = schema or self._database

--- a/rick_db/backend/clickhouse/migrations.py
+++ b/rick_db/backend/clickhouse/migrations.py
@@ -42,16 +42,3 @@ class ClickHouseMigrationManager(BaseMigrationManager):
             return MigrationResult(success=True, error="")
         except Exception as e:
             return MigrationResult(success=False, error=str(e))
-
-    def _exec(self, content):
-        """
-        Execute migration using a cursor.
-        Splits multi-statement SQL on ';' since clickhouse-connect's
-        command() only accepts one statement at a time.
-        """
-        with self.manager.conn() as conn:
-            with conn.cursor() as c:
-                for statement in content.split(";"):
-                    statement = statement.strip()
-                    if statement:
-                        c.exec(statement)

--- a/rick_db/backend/clickhouse/pool.py
+++ b/rick_db/backend/clickhouse/pool.py
@@ -35,6 +35,11 @@ class ClickHouseConnectionPool(PoolInterface):
 
         minconn = kwargs.pop("minconn", self.default_min_conn)
         maxconn = kwargs.pop("maxconn", self.default_max_conn)
+        if minconn < 0 or maxconn < 1 or minconn > maxconn:
+            raise ValueError(
+                f"invalid pool size: minconn={minconn}, maxconn={maxconn} "
+                f"(require 0 <= minconn <= maxconn and maxconn >= 1)"
+            )
         self._autocommit = kwargs.pop("autocommit", False)
 
         self._factory = Connection

--- a/rick_db/backend/clickhouse/pool.py
+++ b/rick_db/backend/clickhouse/pool.py
@@ -1,0 +1,145 @@
+from contextlib import contextmanager
+import logging
+import threading
+
+from rick_db import Connection, PoolInterface
+from rick_db.profiler import NullProfiler
+from rick_db.sql import ClickHouseSqlDialect
+
+from .connection import ClickHouseClientWrapper
+
+logger = logging.getLogger("rick_db.backend.clickhouse")
+
+
+class PoolError(Exception):
+    pass
+
+
+class ClickHouseConnectionPool(PoolInterface):
+    """
+    Thread-safe connection pool for ClickHouse.
+
+    Note: the profiler instance is captured at connection checkout time.
+    Reassigning pool.profiler after connections are already checked out
+    will not affect those existing connections.
+    """
+
+    default_min_conn = 5
+    default_max_conn = 25
+
+    def __init__(self, **kwargs):
+        self._lock = threading.Lock()
+        self.profiler = NullProfiler()
+        self._dialect = ClickHouseSqlDialect()
+        self.ping = kwargs.pop("ping", True)
+
+        minconn = kwargs.pop("minconn", self.default_min_conn)
+        maxconn = kwargs.pop("maxconn", self.default_max_conn)
+        self._autocommit = kwargs.pop("autocommit", False)
+
+        self._factory = Connection
+        self._kwargs = kwargs
+        self._minconn = minconn
+        self._maxconn = maxconn
+        self._pool = []
+        self._used = {}  # id(wrapper) -> wrapper, for cleanup on close()
+        self._closed = False
+
+        self._init_pool(minconn)
+
+    def _init_pool(self, count):
+        for _ in range(count):
+            self._pool.append(self._create_client())
+
+    def _create_client(self):
+        import clickhouse_connect
+
+        client = clickhouse_connect.get_client(**self._kwargs)
+        return ClickHouseClientWrapper(client)
+
+    def dialect(self):
+        return self._dialect
+
+    def connection_factory(self, factory):
+        with self._lock:
+            self._factory = factory
+
+    @contextmanager
+    def connection(self) -> Connection:
+        conn = None
+        try:
+            conn = self.getconn()
+            yield conn
+        finally:
+            if conn:
+                self.putconn(conn)
+
+    def getconn(self) -> Connection:
+        if self._closed:
+            raise PoolError("Connection pool is closed")
+
+        with self._lock:
+            wrapper = self._get_wrapper()
+
+        if self.ping:
+            try:
+                cursor = wrapper.cursor()
+                cursor.execute("SELECT 1")
+                cursor.close()
+            except Exception:
+                logger.warning(
+                    "fetching connection from pool failed (stale connection), replacing..."
+                )
+                try:
+                    wrapper.close()
+                except Exception:
+                    pass
+                # create a fresh wrapper and swap it into the slot
+                new_wrapper = self._create_client()
+                with self._lock:
+                    self._used.pop(id(wrapper), None)
+                    self._used[id(new_wrapper)] = new_wrapper
+                wrapper = new_wrapper
+
+        conn = self._factory(self, wrapper, self._dialect, self.profiler)
+        conn.autocommit = self._autocommit
+        return conn
+
+    def _get_wrapper(self):
+        if self._pool:
+            wrapper = self._pool.pop()
+            self._used[id(wrapper)] = wrapper
+            return wrapper
+
+        if len(self._used) < self._maxconn:
+            wrapper = self._create_client()
+            self._used[id(wrapper)] = wrapper
+            return wrapper
+
+        raise PoolError("Cannot connect to database, no connections available")
+
+    def putconn(self, conn: Connection):
+        with self._lock:
+            if conn.db is not None:
+                self._used.pop(id(conn.db), None)
+                if not self._closed:
+                    self._pool.append(conn.db)
+                else:
+                    conn.db.close()
+                conn.db = None
+
+    def close(self):
+        with self._lock:
+            self._closed = True
+            for wrapper in self._pool:
+                try:
+                    wrapper.close()
+                except Exception:
+                    pass
+            self._pool.clear()
+            for wrapper in self._used.values():
+                try:
+                    wrapper.close()
+                except Exception:
+                    pass
+            self._used.clear()

--- a/rick_db/backend/clickhouse/repository.py
+++ b/rick_db/backend/clickhouse/repository.py
@@ -90,7 +90,7 @@ class ClickHouseRepository(Repository):
         data = record.asrecord()
 
         value = pk_value
-        if self.pk in data.keys():
+        if self.pk in data:
             value = data[self.pk]
             del data[self.pk]
 
@@ -113,14 +113,14 @@ class ClickHouseRepository(Repository):
         :param record: record to update
         :param where_list: list of where conditions
         """
-        if type(where_list) not in [list, tuple]:
+        if not isinstance(where_list, (list, tuple)):
             raise RepositoryError("update_where(): invalid type for where clause list")
         if len(where_list) == 0:
             raise RepositoryError("update_where(): where clause list cannot be empty")
 
         qry = ClickHouseUpdate(self.dialect).table(self.table_name, self.schema).values(record)
         for cond in where_list:
-            if type(cond) not in [list, tuple]:
+            if not isinstance(cond, (list, tuple)):
                 raise RepositoryError(
                     "update_where(): invalid item in where clause list"
                 )

--- a/rick_db/backend/sqlite/migrations.py
+++ b/rick_db/backend/sqlite/migrations.py
@@ -2,6 +2,39 @@ from rick_db.migrations import BaseMigrationManager
 from rick_db.sql import Sqlite3SqlDialect
 
 
+def _split_statements(content):
+    """Split SQL on semicolons, respecting single-quoted strings."""
+    statements = []
+    current = []
+    in_string = False
+    i = 0
+    while i < len(content):
+        ch = content[i]
+        if in_string:
+            current.append(ch)
+            if ch == "'" and i + 1 < len(content) and content[i + 1] == "'":
+                current.append("'")
+                i += 2
+                continue
+            elif ch == "'":
+                in_string = False
+        elif ch == "'":
+            in_string = True
+            current.append(ch)
+        elif ch == ";":
+            stmt = "".join(current).strip()
+            if stmt:
+                statements.append(stmt)
+            current = []
+        else:
+            current.append(ch)
+        i += 1
+    stmt = "".join(current).strip()
+    if stmt:
+        statements.append(stmt)
+    return statements
+
+
 class Sqlite3MigrationManager(BaseMigrationManager):
     def _migration_table_sql(self, table_name: str) -> str:
         """
@@ -19,17 +52,16 @@ class Sqlite3MigrationManager(BaseMigrationManager):
 
     def _exec(self, content):
         """
-        Execute migration using a cursor
+        Execute migration using a cursor.
 
-        Note: statements are split by ';' and executed individually to avoid
-        sqlite3's executescript() which implicitly commits any pending transaction.
+        Statements are split by ';' (respecting quoted strings) and executed
+        individually to avoid sqlite3's executescript() which implicitly
+        commits any pending transaction.
 
         :param content: string
         :return: none
         """
         with self.manager.conn() as conn:
             with conn.cursor() as c:
-                for statement in content.split(";"):
-                    statement = statement.strip()
-                    if statement:
-                        c.exec(statement)
+                for statement in _split_statements(content):
+                    c.exec(statement)

--- a/rick_db/cache.py
+++ b/rick_db/cache.py
@@ -26,7 +26,7 @@ class QueryCache(CacheInterface):
 
     def get(self, key: str, default: Any = None) -> Optional[str]:
         with self._lock:
-            if key in self.data.keys():
+            if key in self.data:
                 return self.data[key]
             return default
 
@@ -36,7 +36,7 @@ class QueryCache(CacheInterface):
 
     def has(self, key: str) -> bool:
         with self._lock:
-            return key in self.data.keys()
+            return key in self.data
 
     def remove(self, key: str) -> Any:
         with self._lock:

--- a/rick_db/cli/commands/dto.py
+++ b/rick_db/cli/commands/dto.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 from typing import List
 from rick_db.cli.command import BaseCommand
@@ -91,6 +92,10 @@ class Command(BaseCommand):
 
         # build fieldmapper decorator fields
         name = table_name.title().replace("_", "")
+        # sanitize: remove chars invalid in Python identifiers, ensure starts with letter
+        name = re.sub(r"[^a-zA-Z0-9]", "", name)
+        if not name or not name[0].isalpha():
+            name = "T" + name
         line = ["tablename='{name}'".format(name=table_name)]
         if schema is not None:
             line.append("schema='{schema}'".format(schema=schema))

--- a/rick_db/cli/config.py
+++ b/rick_db/cli/config.py
@@ -37,7 +37,7 @@ class ConfigFile:
         config = toml.load(self._file)
         for k in config.keys():
             if k.startswith(self.KEY_PREFIX) or k == self.KEY_DEFAULT:
-                if type(config[k]) is dict:
+                if isinstance(config[k], dict):
                     if self.KEY_ENGINE not in config[k].keys():
                         raise RuntimeError(
                             "missing 'engine' parameter in database configuration key '{}' in {}".format(
@@ -57,4 +57,4 @@ class ConfigFile:
         if not p.exists() or not p.is_file():
             raise RuntimeError("could not open passfile '{}'".format(passfile))
         with open(p, encoding="utf-8") as f:
-            return f.readline()
+            return f.readline().rstrip("\n\r")

--- a/rick_db/cli/manage.py
+++ b/rick_db/cli/manage.py
@@ -181,7 +181,7 @@ class CliManager:
         cmds = {}
         for p in path.glob("*.py"):
             if p.is_file() and p.name[0] != "_":
-                command_ns = "{}.{}".format(module_prefix, p.name.rsplit(".py")[0])
+                command_ns = "{}.{}".format(module_prefix, p.stem)
                 loaded = command_ns in sys.modules
                 try:
                     module = importlib.import_module(command_ns)

--- a/rick_db/connection.py
+++ b/rick_db/connection.py
@@ -77,7 +77,7 @@ class Connection(ConnectionInterface):
         pool: Optional[PoolInterface],
         db_connection,
         dialect: SqlDialect,
-        profiler: ProfilerInterface = NullProfiler(),
+        profiler: ProfilerInterface = None,
     ):
         """
         Initializes a connection
@@ -91,7 +91,7 @@ class Connection(ConnectionInterface):
         self._dialect = dialect
         self._in_transaction = False
         self._cursor_factory = Cursor
-        self.profiler = profiler
+        self.profiler = profiler if profiler is not None else NullProfiler()
         # autocommit can either be defined at inherited instances or
         # imported from the database adapter
         if getattr(self, "autocommit", None) is None:

--- a/rick_db/dbgrid.py
+++ b/rick_db/dbgrid.py
@@ -32,7 +32,7 @@ class DbGrid:
             search_type = self.SEARCH_ANY
         else:
             if search_type != self.SEARCH_NONE:
-                if search_type not in self.search_map.keys():
+                if search_type not in self.search_map:
                     raise ValueError("search type '%s' is not supported" % search_type)
 
         self._repo = repo

--- a/rick_db/mapper.py
+++ b/rick_db/mapper.py
@@ -163,11 +163,15 @@ class BaseRecord(Record):
         return self._fieldmap
 
     def add(self, name, value, field_name: str = None):
+        # copy-on-write: avoid mutating the class-level _fieldmap
+        if self._fieldmap is self.__class__._fieldmap:
+            object.__setattr__(self, ATTR_FIELDS, dict(self._fieldmap))
+        fm = object.__getattribute__(self, ATTR_FIELDS)
         if not field_name:
-            self._fieldmap[name] = name
+            fm[name] = name
             field_name = name
         else:
-            self._fieldmap[name] = field_name
+            fm[name] = field_name
         self.__setattr__(name, value)
 
     def __getattribute__(self, attr):
@@ -183,7 +187,7 @@ class BaseRecord(Record):
         fm = object.__getattribute__(self, ATTR_FIELDS)
         if key in fm:
             data = object.__getattribute__(self, ATTR_ROW)
-            if type(data) is not dict:
+            if not isinstance(data, dict):
                 # unwrap dict from dict-like record objects, such as psycopg2 results
                 # this is only necessary when setting values, as original object is often read-only
                 data = dict(data)

--- a/rick_db/migrations.py
+++ b/rick_db/migrations.py
@@ -36,6 +36,7 @@ class BaseMigrationManager:
 
     def __init__(self, mgr: ManagerInterface):
         self.manager = mgr
+        self._repository = None
 
     def is_installed(self) -> bool:
         """
@@ -166,15 +167,16 @@ class BaseMigrationManager:
 
     @property
     def repository(self) -> Repository:
-        # build a patched class based on MigrationRecord, since
-        # existing one has no table name
-        class R(MigrationRecord):
-            pass
+        if self._repository is None:
+            # build a patched class based on MigrationRecord, since
+            # existing one has no table name
+            class R(MigrationRecord):
+                pass
 
-        # define table name
-        setattr(R, ATTR_TABLE, self.MIGRATION_TABLE)
-
-        return Repository(self.manager.backend(), R)
+            # define table name
+            setattr(R, ATTR_TABLE, self.MIGRATION_TABLE)
+            self._repository = Repository(self.manager.backend(), R)
+        return self._repository
 
     @abc.abstractmethod
     def _migration_table_sql(self, table_name: str) -> str:

--- a/rick_db/profiler/profilers.py
+++ b/rick_db/profiler/profilers.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+import threading
 import time
 
 
@@ -31,18 +32,25 @@ class ProfilerInterface:
 
 
 class NullProfiler(ProfilerInterface):
-    pass
+    _empty = EventCollection()
+
+    def get_events(self) -> EventCollection:
+        return self._empty
 
 
 class DefaultProfiler(ProfilerInterface):
     def __init__(self):
         self._events = EventCollection()
+        self._lock = threading.Lock()
 
     def add_event(self, query: str, parameters: dict, duration: float):
-        self._events.append(Event(time.time(), query, parameters, duration))
+        with self._lock:
+            self._events.append(Event(time.time(), query, parameters, duration))
 
     def clear(self):
-        self._events.clear()
+        with self._lock:
+            self._events.clear()
 
     def get_events(self) -> EventCollection:
-        return self._events
+        with self._lock:
+            return EventCollection(self._events)

--- a/rick_db/profiler/profilers.py
+++ b/rick_db/profiler/profilers.py
@@ -32,10 +32,8 @@ class ProfilerInterface:
 
 
 class NullProfiler(ProfilerInterface):
-    _empty = EventCollection()
-
     def get_events(self) -> EventCollection:
-        return self._empty
+        return EventCollection()
 
 
 class DefaultProfiler(ProfilerInterface):

--- a/rick_db/repository.py
+++ b/rick_db/repository.py
@@ -566,7 +566,7 @@ class Repository(GenericRepository):
         data = record.asrecord()  # type: dict
 
         value = pk_value
-        if self.pk in data.keys():
+        if self.pk in data:
             # if primary key already on record, extract it and remove it from update list
             value = data[self.pk]
             del data[self.pk]
@@ -593,14 +593,14 @@ class Repository(GenericRepository):
         :param where_list: list of where conditions
         :return:
         """
-        if type(where_list) not in [list, tuple]:
+        if not isinstance(where_list, (list, tuple)):
             raise RepositoryError("update_where(): invalid type for where clause list")
         if len(where_list) == 0:
             raise RepositoryError("update_where(): where clause list cannot be empty")
 
         qry = Update(self.dialect).table(self.table_name, self.schema).values(record)
         for cond in where_list:
-            if type(cond) not in [list, tuple]:
+            if not isinstance(cond, (list, tuple)):
                 raise RepositoryError(
                     "update_where(): invalid item in where clause list"
                 )
@@ -646,14 +646,14 @@ class Repository(GenericRepository):
         :param where_list: list of where conditions
         :return:
         """
-        if type(where_list) not in [list, tuple]:
+        if not isinstance(where_list, (list, tuple)):
             raise RepositoryError("count_where(): invalid type for where clause list")
         if len(where_list) == 0:
             raise RepositoryError("count_where(): where clause list cannot be empty")
 
         qry = self.select(cols={Literal("COUNT(*)"): "total"})
         for cond in where_list:
-            if type(cond) not in [list, tuple]:
+            if not isinstance(cond, (list, tuple)):
                 raise RepositoryError(
                     "count_where(): invalid item in where clause list"
                 )

--- a/rick_db/sql/common.py
+++ b/rick_db/sql/common.py
@@ -105,10 +105,11 @@ class JsonField:
             json_field = JsonField('data')
             json_field['name']  # Returns the expression to extract the 'name' field
         """
-        # Create a new JsonField with modified field name to represent the JSON path
-        field_path = f'{self.field_name}->>"{key}"'
-        result = JsonField(field_path, self.dialect)
-        return result
+        if self.dialect and self.dialect.json_support:
+            expr = self.dialect.json_extract(self.field_name, key)
+            return JsonField(expr, self.dialect)
+        field_path = f"JSON_EXTRACT({self.field_name}, '$.{key}')"
+        return JsonField(field_path, self.dialect)
 
 
 class PgJsonField(JsonField):

--- a/rick_db/sql/insert.py
+++ b/rick_db/sql/insert.py
@@ -78,7 +78,7 @@ class Insert(SqlStatement):
             self._values = values
 
         elif isinstance(values, collections.abc.Mapping):
-            self._fields = values.keys()
+            self._fields = list(values.keys())
             self._values = list(values.values())
 
         elif isinstance(values, object):
@@ -86,7 +86,7 @@ class Insert(SqlStatement):
             if not callable(getattr(values, "asrecord", None)):
                 raise SqlError("values(): invalid object type for data parameter")
             values = values.asrecord()
-            self._fields = values.keys()
+            self._fields = list(values.keys())
             self._values = list(values.values())
         else:
             raise SqlError("values(): Invalid data type")

--- a/rick_db/sql/select.py
+++ b/rick_db/sql/select.py
@@ -927,7 +927,6 @@ class Select(SqlStatement):
             else:
                 if (
                     isinstance(value, (list, tuple))
-                    and operator is not None
                     and operator.lower() in ("in", "not in")
                 ):
                     if len(value) == 0:
@@ -1062,7 +1061,7 @@ class Select(SqlStatement):
         # always alias wildcard tables
         has_alias = False
         if join_type in (Sql.FROM, Sql.LATERAL):
-            has_alias = (join_table != alias) or str(cols) == "*"
+            has_alias = (join_table != alias) or cols == "*"
         else:
             # in joins, cols are always prefixed by alias
             if cols is not None:

--- a/rick_db/version.py
+++ b/rick_db/version.py
@@ -1,4 +1,4 @@
-RICK_DB_VERSION = ["2", "2", "2"]
+RICK_DB_VERSION = ["2", "2", "3"]
 
 
 def get_version():

--- a/tests/backend/clickhouse/test_clickhouse_manager.py
+++ b/tests/backend/clickhouse/test_clickhouse_manager.py
@@ -1,6 +1,10 @@
 import pytest
 
-from rick_db.backend.clickhouse import ClickHouseConnection, ClickHouseManager
+from rick_db.backend.clickhouse import (
+    ClickHouseConnection,
+    ClickHouseConnectionPool,
+    ClickHouseManager,
+)
 
 create_table = """
 CREATE TABLE IF NOT EXISTS animal (
@@ -185,3 +189,70 @@ class TestClickHouseManager:
         assert mgr.view_exists("list_animal") is True
         mgr.drop_view("list_animal")
         assert mgr.view_exists("list_animal") is False
+
+
+class TestClickHouseManagerWithPool:
+    @pytest.fixture
+    def ch_pool(self, ch_settings):
+        try:
+            pool = ClickHouseConnectionPool(**ch_settings, ping=False, minconn=1, maxconn=5)
+        except Exception:
+            pytest.skip("ClickHouse server not available")
+            return
+
+        try:
+            with pool.connection() as conn:
+                with conn.cursor() as c:
+                    c.exec("SELECT 1")
+        except Exception:
+            pool.close()
+            pytest.skip("ClickHouse server not available")
+            return
+
+        yield pool
+
+        # cleanup
+        if not pool._closed:
+            mgr = ClickHouseManager(pool)
+            mgr.drop_table("animal")
+            mgr.drop_view("list_animal")
+            pool.close()
+
+    def test_pool_backend(self, ch_pool):
+        mgr = ClickHouseManager(ch_pool)
+        assert mgr.backend() is ch_pool
+
+    def test_pool_tables(self, ch_pool):
+        mgr = ClickHouseManager(ch_pool)
+        with mgr.conn() as conn:
+            with conn.cursor() as c:
+                c.exec(create_table)
+
+        tables = mgr.tables()
+        assert "animal" in tables
+        assert mgr.table_exists("animal") is True
+
+        mgr.drop_table("animal")
+        assert mgr.table_exists("animal") is False
+
+    def test_pool_databases(self, ch_pool):
+        mgr = ClickHouseManager(ch_pool)
+        dbs = mgr.databases()
+        assert "system" in dbs
+
+    def test_pool_table_fields(self, ch_pool):
+        mgr = ClickHouseManager(ch_pool)
+        with mgr.conn() as conn:
+            with conn.cursor() as c:
+                c.exec(create_table)
+
+        fields = mgr.table_fields("animal")
+        assert len(fields) == 2
+        assert fields[0].field == "id_animal"
+        assert fields[0].primary is True
+
+    def test_pool_explicit_database(self, ch_pool):
+        mgr = ClickHouseManager(ch_pool, database="system")
+        tables = mgr.tables()
+        # system database has system tables
+        assert len(tables) > 0

--- a/tests/backend/clickhouse/test_clickhouse_migrations.py
+++ b/tests/backend/clickhouse/test_clickhouse_migrations.py
@@ -148,22 +148,21 @@ class TestClickHouseMigrationManager:
         result = mm.execute(MigrationRecord(name="test"), "")
         assert result.success is False
 
-    def test_exec_multi_statement(self, mm):
-        """Test that _exec splits multi-statement SQL correctly"""
+    def test_execute_single_statement(self, mm):
+        """Each migration file should contain a single SQL statement."""
         mm.install()
 
-        multi_sql = """
+        create_sql = """
         CREATE TABLE IF NOT EXISTS animal (
             id_animal UInt32,
             name String
         ) ENGINE = MergeTree()
-        ORDER BY id_animal;
-        INSERT INTO animal VALUES (1, 'cat');
-        INSERT INTO animal VALUES (2, 'dog')
+        ORDER BY id_animal
         """
 
-        mig = MigrationRecord(name="multi_stmt")
-        result = mm.execute(mig, multi_sql)
+        mig = MigrationRecord(name="single_stmt")
+        result = mm.execute(mig, create_sql)
         assert result.success is True
+        assert mm.manager.table_exists("animal") is True
 
         mm.manager.drop_table("animal")

--- a/tests/backend/clickhouse/test_clickhouse_pool.py
+++ b/tests/backend/clickhouse/test_clickhouse_pool.py
@@ -242,6 +242,46 @@ class TestClickHousePool:
         pool.putconn(conn)
         pool.close()
 
+    @patch("clickhouse_connect.get_client", side_effect=_mock_get_client)
+    def test_pool_profiler_snapshot_at_checkout(self, mock_client):
+        """Profiler is captured at checkout time; reassigning pool.profiler does not affect existing connections."""
+        pool = ClickHouseConnectionPool(
+            host="localhost", ping=False, minconn=2, maxconn=5
+        )
+        profiler1 = DefaultProfiler()
+        pool.profiler = profiler1
+
+        # checkout conn1 with profiler1
+        conn1 = pool.getconn()
+        assert conn1.profiler is profiler1
+
+        # reassign pool profiler
+        profiler2 = DefaultProfiler()
+        pool.profiler = profiler2
+
+        # checkout conn2 with profiler2
+        conn2 = pool.getconn()
+        assert conn2.profiler is profiler2
+
+        # conn1 still has profiler1
+        assert conn1.profiler is profiler1
+        assert conn1.profiler is not profiler2
+
+        # execute on both — events go to their respective profilers
+        with conn1.cursor() as c:
+            c.exec("SELECT 1")
+        with conn2.cursor() as c:
+            c.exec("SELECT 2")
+
+        assert len(profiler1.get_events()) == 1
+        assert profiler1.get_events()[0].query == "SELECT 1"
+        assert len(profiler2.get_events()) == 1
+        assert profiler2.get_events()[0].query == "SELECT 2"
+
+        pool.putconn(conn1)
+        pool.putconn(conn2)
+        pool.close()
+
 
 class TestClickHousePoolIntegration:
 

--- a/tests/backend/clickhouse/test_clickhouse_pool.py
+++ b/tests/backend/clickhouse/test_clickhouse_pool.py
@@ -1,0 +1,513 @@
+import threading
+import time
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from rick_db import Connection, Cursor, fieldmapper
+from rick_db.backend.clickhouse import ClickHouseConnectionPool, ClickHouseRepository
+from rick_db.backend.clickhouse.pool import PoolError
+from rick_db.profiler import NullProfiler, DefaultProfiler
+from rick_db.sql import ClickHouseSqlDialect
+
+
+class SampleConnection(Connection):
+    pass
+
+
+@fieldmapper(tablename="pool_test", pk="id")
+class PoolTestRecord:
+    id = "id"
+    value = "value"
+
+
+create_table = """
+CREATE TABLE IF NOT EXISTS pool_test (
+    id UInt32,
+    value String DEFAULT ''
+) ENGINE = MergeTree()
+ORDER BY id
+"""
+
+drop_table = "DROP TABLE IF EXISTS pool_test"
+
+
+@pytest.fixture
+def ch_pool(ch_settings):
+    try:
+        pool = ClickHouseConnectionPool(**ch_settings, ping=True, minconn=2, maxconn=10)
+    except Exception:
+        pytest.skip("ClickHouse server not available")
+        return
+
+    # verify connectivity
+    try:
+        with pool.connection() as conn:
+            with conn.cursor() as c:
+                c.exec("SELECT 1")
+    except Exception:
+        pool.close()
+        pytest.skip("ClickHouse server not available")
+        return
+
+    # setup table
+    with pool.connection() as conn:
+        with conn.cursor() as c:
+            c.exec(drop_table)
+            c.exec(create_table)
+
+    yield pool
+
+    # teardown
+    if not pool._closed:
+        with pool.connection() as conn:
+            with conn.cursor() as c:
+                c.exec(drop_table)
+        pool.close()
+    else:
+        # pool was closed by test; use a direct connection for cleanup
+        from rick_db.backend.clickhouse import ClickHouseConnection
+        conn = ClickHouseConnection(**ch_settings)
+        with conn.cursor() as c:
+            c.exec(drop_table)
+        conn.close()
+
+
+def _mock_get_client(**kwargs):
+    client = MagicMock()
+    result = MagicMock()
+    result.column_names = ["1"]
+    result.result_rows = [(1,)]
+    client.query.return_value = result
+    return client
+
+
+class TestClickHousePool:
+
+    @patch("clickhouse_connect.get_client", side_effect=_mock_get_client)
+    def test_pool_init(self, mock_client):
+        pool = ClickHouseConnectionPool(
+            host="localhost", ping=False, minconn=2, maxconn=5
+        )
+        assert pool is not None
+        assert isinstance(pool.profiler, NullProfiler)
+        assert isinstance(pool.dialect(), ClickHouseSqlDialect)
+        assert pool._factory is Connection
+        assert len(pool._pool) == 2
+        assert pool._maxconn == 5
+        pool.close()
+
+    @patch("clickhouse_connect.get_client", side_effect=_mock_get_client)
+    def test_pool_getconn(self, mock_client):
+        pool = ClickHouseConnectionPool(
+            host="localhost", ping=False, minconn=2, maxconn=5
+        )
+        conn = pool.getconn()
+        assert conn is not None
+        assert isinstance(conn, Connection)
+        assert len(pool._pool) == 1
+        pool.putconn(conn)
+        assert conn.db is None
+        assert len(pool._pool) == 2
+        pool.close()
+
+    @patch("clickhouse_connect.get_client", side_effect=_mock_get_client)
+    def test_pool_cursor(self, mock_client):
+        pool = ClickHouseConnectionPool(
+            host="localhost", ping=False, minconn=2, maxconn=5
+        )
+        conn = pool.getconn()
+        assert isinstance(conn, Connection)
+        cursor = conn.get_cursor()
+        assert isinstance(cursor, Cursor)
+        result = cursor.fetchone("SELECT 1")
+        assert result is not None
+        pool.putconn(conn)
+        pool.close()
+
+    @patch("clickhouse_connect.get_client", side_effect=_mock_get_client)
+    def test_pool_ctx(self, mock_client):
+        pool = ClickHouseConnectionPool(
+            host="localhost", ping=False, minconn=2, maxconn=5
+        )
+        with pool.connection() as conn:
+            assert conn is not None
+            assert isinstance(conn, Connection)
+        # conn returned to pool
+        assert len(pool._pool) == 2
+        pool.close()
+
+    @patch("clickhouse_connect.get_client", side_effect=_mock_get_client)
+    def test_pool_exhaust(self, mock_client):
+        pool = ClickHouseConnectionPool(
+            host="localhost", ping=False, minconn=1, maxconn=3
+        )
+        conns = []
+        with pytest.raises(PoolError):
+            for i in range(10):
+                conns.append(pool.getconn())
+        assert len(conns) == 3
+        for conn in conns:
+            pool.putconn(conn)
+        pool.close()
+
+    @patch("clickhouse_connect.get_client", side_effect=_mock_get_client)
+    def test_pool_closed(self, mock_client):
+        pool = ClickHouseConnectionPool(
+            host="localhost", ping=False, minconn=1, maxconn=3
+        )
+        pool.close()
+        with pytest.raises(PoolError):
+            pool.getconn()
+
+    @patch("clickhouse_connect.get_client", side_effect=_mock_get_client)
+    def test_pool_factory(self, mock_client):
+        pool = ClickHouseConnectionPool(
+            host="localhost", ping=False, minconn=2, maxconn=5
+        )
+        assert pool._factory is Connection
+        pool.connection_factory(SampleConnection)
+        assert pool._factory is SampleConnection
+        with pool.connection() as conn:
+            assert isinstance(conn, SampleConnection)
+        pool.close()
+
+    @patch("clickhouse_connect.get_client", side_effect=_mock_get_client)
+    def test_pool_putconn_twice(self, mock_client):
+        pool = ClickHouseConnectionPool(
+            host="localhost", ping=False, minconn=2, maxconn=5
+        )
+        conn = pool.getconn()
+        pool.putconn(conn)
+        assert conn.db is None
+        # second putconn should be a no-op
+        pool.putconn(conn)
+        assert len(pool._pool) == 2
+        pool.close()
+
+    @patch("clickhouse_connect.get_client", side_effect=_mock_get_client)
+    def test_pool_ping(self, mock_client):
+        pool = ClickHouseConnectionPool(
+            host="localhost", ping=True, minconn=1, maxconn=3
+        )
+        conn = pool.getconn()
+        assert conn is not None
+        pool.putconn(conn)
+        pool.close()
+
+    @patch("clickhouse_connect.get_client", side_effect=_mock_get_client)
+    def test_pool_grows_beyond_min(self, mock_client):
+        pool = ClickHouseConnectionPool(
+            host="localhost", ping=False, minconn=1, maxconn=3
+        )
+        conns = []
+        conns.append(pool.getconn())
+        conns.append(pool.getconn())
+        assert len(conns) == 2
+        for conn in conns:
+            pool.putconn(conn)
+        # pool now has 2 connections (grew from min=1)
+        assert len(pool._pool) == 2
+        pool.close()
+
+    @patch("clickhouse_connect.get_client", side_effect=_mock_get_client)
+    def test_pool_close_with_checked_out_connections(self, mock_client):
+        pool = ClickHouseConnectionPool(
+            host="localhost", ping=False, minconn=2, maxconn=5
+        )
+        conn = pool.getconn()
+        assert len(pool._used) == 1
+        pool.close()
+        # close() should close both idle and in-use wrappers
+        assert len(pool._pool) == 0
+        assert len(pool._used) == 0
+        assert pool._closed is True
+
+    @patch("clickhouse_connect.get_client", side_effect=_mock_get_client)
+    def test_pool_stale_connection_recovery(self, mock_client):
+        """Ping failure should replace the stale wrapper with a fresh one."""
+        pool = ClickHouseConnectionPool(
+            host="localhost", ping=True, minconn=1, maxconn=3
+        )
+        # make the first pooled wrapper's cursor raise on execute (stale)
+        stale_wrapper = pool._pool[0]
+        stale_cursor = MagicMock()
+        stale_cursor.execute.side_effect = Exception("connection lost")
+        stale_wrapper.cursor = MagicMock(return_value=stale_cursor)
+
+        conn = pool.getconn()
+        assert conn is not None
+        # the wrapper should NOT be the stale one
+        assert conn.db is not stale_wrapper
+        pool.putconn(conn)
+        pool.close()
+
+
+class TestClickHousePoolIntegration:
+
+    def test_pool_connect(self, ch_pool):
+        assert ch_pool is not None
+        assert isinstance(ch_pool.dialect(), ClickHouseSqlDialect)
+
+    def test_pool_cursor_select(self, ch_pool):
+        with ch_pool.connection() as conn:
+            with conn.cursor() as c:
+                result = c.exec("SELECT 1 AS val")
+                assert len(result) == 1
+                assert result[0]["val"] == 1
+
+    def test_pool_getconn_putconn(self, ch_pool):
+        conn = ch_pool.getconn()
+        assert conn is not None
+        assert isinstance(conn, Connection)
+        with conn.cursor() as c:
+            result = c.fetchone("SELECT 1 AS val")
+            assert result["val"] == 1
+        ch_pool.putconn(conn)
+        assert conn.db is None
+
+    def test_pool_multiple_connections(self, ch_pool):
+        conns = [ch_pool.getconn() for _ in range(5)]
+        assert len(conns) == 5
+        for conn in conns:
+            with conn.cursor() as c:
+                r = c.fetchone("SELECT 1 AS val")
+                assert r["val"] == 1
+        for conn in conns:
+            ch_pool.putconn(conn)
+
+    def test_pool_connection_reuse(self, ch_pool):
+        with ch_pool.connection() as conn1:
+            db1 = conn1.db
+        # after returning, get another connection - should reuse
+        with ch_pool.connection() as conn2:
+            db2 = conn2.db
+        assert db1 is db2
+
+    def test_pool_insert_and_read(self, ch_pool):
+        with ch_pool.connection() as conn:
+            repo = ClickHouseRepository(conn, PoolTestRecord)
+            repo.insert(PoolTestRecord(id=1, value="hello"))
+
+        with ch_pool.connection() as conn:
+            repo = ClickHouseRepository(conn, PoolTestRecord)
+            record = repo.fetch_pk(1)
+            assert record is not None
+            assert record.value == "hello"
+
+    def test_pool_exhaust(self, ch_pool):
+        conns = []
+        with pytest.raises(PoolError):
+            for _ in range(20):
+                conns.append(ch_pool.getconn())
+        for conn in conns:
+            ch_pool.putconn(conn)
+
+    def test_pool_closed(self, ch_pool):
+        ch_pool.close()
+        with pytest.raises(PoolError):
+            ch_pool.getconn()
+
+    def test_pool_context_returns_on_exception(self, ch_pool):
+        initial_count = len(ch_pool._pool)
+        try:
+            with ch_pool.connection() as conn:
+                raise ValueError("test error")
+        except ValueError:
+            pass
+        assert len(ch_pool._pool) == initial_count
+
+    def test_pool_profiler(self, ch_pool):
+        profiler = DefaultProfiler()
+        ch_pool.profiler = profiler
+
+        with ch_pool.connection() as conn:
+            with conn.cursor() as c:
+                c.exec("SELECT 1 AS val")
+                c.exec("SELECT 2 AS val")
+
+        events = profiler.get_events()
+        assert len(events) >= 2
+        queries = [e.query for e in events]
+        assert "SELECT 1 AS val" in queries
+        assert "SELECT 2 AS val" in queries
+        for e in events:
+            assert e.elapsed >= 0
+
+    def test_pool_profiler_across_connections(self, ch_pool):
+        profiler = DefaultProfiler()
+        ch_pool.profiler = profiler
+
+        with ch_pool.connection() as conn:
+            with conn.cursor() as c:
+                c.exec("SELECT 'conn1' AS src")
+
+        with ch_pool.connection() as conn:
+            with conn.cursor() as c:
+                c.exec("SELECT 'conn2' AS src")
+
+        events = profiler.get_events()
+        queries = [e.query for e in events]
+        assert "SELECT 'conn1' AS src" in queries
+        assert "SELECT 'conn2' AS src" in queries
+
+    def test_pool_stale_connection_recovery(self, ch_pool):
+        """Force a wrapper to be stale and verify ping replaces it."""
+        # get a connection and sabotage its wrapper before returning
+        conn = ch_pool.getconn()
+        wrapper = conn.db
+        ch_pool.putconn(conn)
+
+        # sabotage the wrapper so ping fails
+        original_cursor = wrapper.cursor
+        def broken_cursor():
+            c = MagicMock()
+            c.execute.side_effect = Exception("connection lost")
+            return c
+        wrapper.cursor = broken_cursor
+
+        # getconn should detect stale via ping and create a fresh wrapper
+        conn2 = ch_pool.getconn()
+        assert conn2 is not None
+        assert conn2.db is not wrapper
+        # the fresh connection should work
+        with conn2.cursor() as c:
+            result = c.fetchone("SELECT 1 AS val")
+            assert result["val"] == 1
+        ch_pool.putconn(conn2)
+
+    def test_concurrent_reads(self, ch_pool):
+        # seed data
+        with ch_pool.connection() as conn:
+            with conn.cursor() as c:
+                for i in range(100, 110):
+                    c.exec(
+                        "INSERT INTO pool_test (id, value) VALUES (%s, %s)",
+                        [i, f"row_{i}"],
+                    )
+
+        errors = []
+        results = []
+        barrier = threading.Barrier(5, timeout=10)
+
+        def worker():
+            try:
+                barrier.wait()
+                with ch_pool.connection() as conn:
+                    repo = ClickHouseRepository(conn, PoolTestRecord)
+                    rows = repo.fetch_all()
+                    results.append(len(rows))
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=15)
+
+        assert len(errors) == 0, f"Thread errors: {errors}"
+        assert len(results) == 5
+        for count in results:
+            assert count >= 10
+
+    def test_concurrent_writes(self, ch_pool):
+        errors = []
+        barrier = threading.Barrier(5, timeout=10)
+
+        def writer(offset):
+            try:
+                barrier.wait()
+                with ch_pool.connection() as conn:
+                    with conn.cursor() as c:
+                        for i in range(5):
+                            row_id = offset + i
+                            c.exec(
+                                "INSERT INTO pool_test (id, value) VALUES (%s, %s)",
+                                [row_id, f"concurrent_{row_id}"],
+                            )
+            except Exception as e:
+                errors.append(e)
+
+        threads = [
+            threading.Thread(target=writer, args=(1000 + i * 100,))
+            for i in range(5)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=15)
+
+        assert len(errors) == 0, f"Thread errors: {errors}"
+
+        # verify all rows were written
+        with ch_pool.connection() as conn:
+            with conn.cursor() as c:
+                result = c.fetchone(
+                    "SELECT count() AS cnt FROM pool_test WHERE id >= 1000"
+                )
+                assert result["cnt"] == 25
+
+    def test_concurrent_checkout_return(self, ch_pool):
+        """Verify pool integrity under rapid concurrent checkout/return cycles."""
+        errors = []
+        barrier = threading.Barrier(8, timeout=10)
+
+        def churn():
+            try:
+                barrier.wait()
+                for _ in range(10):
+                    conn = ch_pool.getconn()
+                    with conn.cursor() as c:
+                        c.exec("SELECT 1")
+                    ch_pool.putconn(conn)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=churn) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+
+        assert len(errors) == 0, f"Thread errors: {errors}"
+        # all connections should be back in the pool
+        assert len(ch_pool._used) == 0
+        assert len(ch_pool._pool) > 0
+
+    def test_concurrent_pool_exhaust_and_return(self, ch_pool):
+        """Threads compete for a limited pool; all should succeed since maxconn=10."""
+        errors = []
+        completed = []
+        lock = threading.Lock()
+        barrier = threading.Barrier(10, timeout=10)
+
+        def grab_and_hold(hold_time):
+            try:
+                barrier.wait()
+                conn = ch_pool.getconn()
+                with conn.cursor() as c:
+                    c.exec("SELECT 1")
+                time.sleep(hold_time)
+                ch_pool.putconn(conn)
+                with lock:
+                    completed.append(True)
+            except PoolError:
+                with lock:
+                    completed.append(False)
+            except Exception as e:
+                errors.append(e)
+
+        # 10 threads compete for maxconn=10 pool
+        threads = [
+            threading.Thread(target=grab_and_hold, args=(0.05,))
+            for _ in range(10)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=15)
+
+        assert len(errors) == 0, f"Thread errors: {errors}"
+        # all 10 should succeed since maxconn=10
+        assert completed.count(True) == 10

--- a/tests/sql/test_json_fields.py
+++ b/tests/sql/test_json_fields.py
@@ -135,7 +135,7 @@ class TestJsonFieldDefault:
         result = jf["name"]
         assert isinstance(result, JsonField)
         assert not isinstance(result, PgJsonField)
-        assert result.field_name == 'data->>"name"'
+        assert result.field_name == "JSON_EXTRACT(data, '$.name')"
 
     def test_str(self):
         jf = JsonField("data")

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -1,0 +1,60 @@
+from rick_db.profiler import NullProfiler, DefaultProfiler
+from rick_db.profiler.profilers import EventCollection
+
+
+class TestNullProfiler:
+    def test_get_events_returns_empty_collection(self):
+        p = NullProfiler()
+        events = p.get_events()
+        assert isinstance(events, EventCollection)
+        assert len(events) == 0
+
+    def test_get_events_returns_fresh_instance(self):
+        p = NullProfiler()
+        e1 = p.get_events()
+        e2 = p.get_events()
+        assert e1 is not e2
+
+    def test_add_event_is_noop(self):
+        p = NullProfiler()
+        p.add_event("SELECT 1", None, 0.01)
+        assert len(p.get_events()) == 0
+
+    def test_clear_is_noop(self):
+        p = NullProfiler()
+        p.clear()
+        assert len(p.get_events()) == 0
+
+
+class TestDefaultProfiler:
+    def test_add_and_get_events(self):
+        p = DefaultProfiler()
+        p.add_event("SELECT 1", None, 0.01)
+        p.add_event("SELECT 2", {"id": 1}, 0.02)
+        events = p.get_events()
+        assert len(events) == 2
+        assert events[0].query == "SELECT 1"
+        assert events[1].query == "SELECT 2"
+        assert events[1].parameters == {"id": 1}
+
+    def test_get_events_returns_snapshot(self):
+        p = DefaultProfiler()
+        p.add_event("SELECT 1", None, 0.01)
+        snapshot = p.get_events()
+        p.add_event("SELECT 2", None, 0.02)
+        assert len(snapshot) == 1
+
+    def test_clear(self):
+        p = DefaultProfiler()
+        p.add_event("SELECT 1", None, 0.01)
+        p.clear()
+        assert len(p.get_events()) == 0
+
+    def test_filter_duration(self):
+        p = DefaultProfiler()
+        p.add_event("fast", None, 0.001)
+        p.add_event("slow", None, 1.5)
+        events = p.get_events()
+        slow = events.filter_duration(1.0)
+        assert len(slow) == 1
+        assert slow[0].query == "slow"

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ healthcheck_start_period = 1
 host_var = PGHOST
 
 [docker:clickhouse_db]
-image=clickhouse/clickhouse-server:25.8
+image=clickhouse/clickhouse-server:25.6
 environment =
     CLICKHOUSE_USER=some_user
     CLICKHOUSE_PASSWORD=somePassword


### PR DESCRIPTION
Add thread-safe ClickHouseConnectionPool with configurable min/max connections, ping-based health checks, stale connection recovery, and profiler passthrough. Update ClickHouseManager to accept both connections and pools. Remove unsafe multi-statement SQL splitting from ClickHouse migrations.

Fix critical bugs: NullProfiler.get_events() returning None, migration repository recreated on every access, SQLite migration splitting breaking on semicolons in string literals. Make DefaultProfiler thread-safe. Fix type() vs isinstance() checks, mutable default arguments, dict_keys views, password file newline stripping, DTO class name sanitization, and JsonField dialect awareness. Update documentation and examples.

## Summary by Sourcery

Introduce a thread-safe ClickHouse connection pool, extend ClickHouse management and documentation to support it, and fix multiple correctness and concurrency issues across migrations, profiling, and core utilities.

New Features:
- Add ClickHouseConnectionPool with configurable size, health checks, and profiler integration for ClickHouse connections.
- Allow ClickHouseManager to work with both single connections and ClickHouseConnectionPool, including an optional database override.

Bug Fixes:
- Ensure SQLite and ClickHouse migrations no longer rely on naive semicolon-based SQL splitting, preventing failures with semicolons inside string literals.
- Cache BaseMigrationManager.repository instead of recreating it on every access to avoid redundant repositories and enable reuse.
- Make DefaultProfiler thread-safe and have NullProfiler.get_events() return an empty event collection instead of None.
- Fix type checking, mutable defaults, dict key handling, JSON field dialect awareness, password file newline handling, DTO name generation, and minor repository and SQL builder issues affecting correctness across backends.

Enhancements:
- Add extensive unit, integration, and concurrency tests for ClickHouseConnectionPool and its use with ClickHouseManager and repositories.
- Update ClickHouse examples and class-level documentation to demonstrate and clarify pooled ClickHouse usage and migration support.
- Clarify ClickHouseManager semantics for unsupported methods and document that user_groups() returns an empty result instead of raising.

Build:
- Update ClickHouse Docker image tag in tox configuration to a valid version for CI and local testing.