### PR TITLE
Fix JSON-path / DTO injection, bump to 2.2.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ jobs:
   test:
     name: Test (py${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    # Ryuk (the testcontainers reaper) is unnecessary on ephemeral runners and
+    # its image pull from Docker Hub is a flaky failure point — disable it.
+    env:
+      TESTCONTAINERS_RYUK_DISABLED: "true"
     strategy:
       fail-fast: false
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,10 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+
+# IDE
+.idea/
+
+# pipenv (project uses requirements*.txt / setup.cfg)
+Pipfile
+Pipfile.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [2.2.4]
+
+### Changed
+- **Testing**: Replaced the `tox-docker` setup with [testcontainers](https://testcontainers.com/). The PostgreSQL and ClickHouse containers used by the integration tests are now started and stopped from `tests/conftest.py` (session-scoped fixtures), so the suite can be run with a plain `pytest` invocation and no longer depends on `tox` or environment-variable wiring. Removed the `[docker:*]` sections from `tox.ini` and swapped `tox-docker` for `testcontainers[postgres]` in `requirements-dev.txt`.
+
+### CI
+- Added a `CI` GitHub Actions workflow (test matrix on Python 3.10–3.14, flake8/black lint, build, `pip-audit` + `bandit` security scan, gated by a `ci-success` job), replacing `run-tests.yml`.
+- Reworked the SBOM workflow to generate CycloneDX + SPDX SBOMs, scan them with Grype, sign them with Cosign, and upload them to the release (with optional Dependency-Track submission).
+
 ## [2.2.3]
 
 ### Security
@@ -13,11 +22,6 @@
 
 ### Changed
 - Dependencies bumped to latest releases: `psycopg2`/`psycopg2-binary` 2.9.12, `toml` 0.10.2, `setuptools` 82.0.1, `clickhouse-connect` >=1.1.1, and dev tooling (`pytest` 9.0.3, `pytest-cov` 7.1.0, `coverage` 7.14.1, `tox` 4.55.0, `mkdocs-material` 9.7.6, `mdx-include` 1.4.2).
-- **Testing**: Replaced the `tox-docker` setup with [testcontainers](https://testcontainers.com/). The PostgreSQL and ClickHouse containers used by the integration tests are now started and stopped from `tests/conftest.py` (session-scoped fixtures), so the suite can be run with a plain `pytest` invocation and no longer depends on `tox` or environment-variable wiring. Removed the `[docker:*]` sections from `tox.ini` and swapped `tox-docker` for `testcontainers[postgres]` in `requirements-dev.txt`.
-
-### CI
-- Added a `CI` GitHub Actions workflow (test matrix on Python 3.10–3.14, flake8/black lint, build, `pip-audit` + `bandit` security scan, gated by a `ci-success` job).
-- Reworked the SBOM workflow to generate CycloneDX + SPDX SBOMs, scan them with Grype, sign them with Cosign, and upload them to the release (with optional Dependency-Track submission).
 
 ## [2.2.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 ### Changed
 - Dependencies bumped to latest releases: `psycopg2`/`psycopg2-binary` 2.9.12, `toml` 0.10.2, `setuptools` 82.0.1, `clickhouse-connect` >=1.1.1, and dev tooling (`pytest` 9.0.3, `pytest-cov` 7.1.0, `coverage` 7.14.1, `tox` 4.55.0, `mkdocs-material` 9.7.6, `mdx-include` 1.4.2).
 
+### Documentation
+- **docs/json_operations.md**: Added a security warning clarifying that JSON paths are interpolated (not parameterized) and must not be built from untrusted input, and corrected the no-dialect `JsonField['name']` example output.
+- **docs/classes/pgjsonfield.md, docs/json_operations.md**: Updated `PgJsonField` `->` examples to use single-quoted JSON keys (`data->'name'`) to match the corrected operator output.
+
 ## [2.2.2]
 
 ### Added

--- a/docs/classes/pgjsonfield.md
+++ b/docs/classes/pgjsonfield.md
@@ -170,12 +170,12 @@ jf = PgJsonField('data', pg)
 
 # Single level
 nested = jf['address']
-# output: data->"address"::jsonb
+# output: data->'address'::jsonb
 print(nested)
 
 # Nested access
 nested = jf['address']['city']
-# output: data->"address"->"city"::jsonb
+# output: data->'address'->'city'::jsonb
 print(nested)
 ```
 

--- a/docs/json_operations.md
+++ b/docs/json_operations.md
@@ -12,6 +12,13 @@ JSON support is available at two levels:
   and JSONB type casting
 - **Select helpers** - Convenience methods on the `Select` class: `json_field()`, `json_extract()`, and `json_where()`
 
+!!! warning "JSON paths are interpolated, not parameterized"
+    Unlike scalar values passed to `where()`/`values()` (which always become bound placeholders), the JSON **path**
+    argument is rendered directly into the SQL text. Embedded single quotes are escaped to prevent the path from
+    breaking out of its string literal, but a path is still SQL, not data. **Do not build JSON paths from untrusted
+    input.** If a path must come from user input, validate it against an allow-list of known keys first. The
+    **value** compared against a JSON expression (e.g. in `json_where()` or `contains()`) is parameterized and safe.
+
 ## JsonField
 
 The `JsonField` class wraps a JSON column name and provides methods that generate SQL expressions as `Literal` objects,
@@ -94,7 +101,7 @@ from rick_db.sql import JsonField
 jf = JsonField('data')
 
 nested = jf['name']
-# output: data->>"name"
+# output (no dialect): JSON_EXTRACT(data, '$.name')
 print(nested)
 ```
 
@@ -185,12 +192,12 @@ jf = PgJsonField('data', pg)
 
 # Single level
 nested = jf['address']
-# output: data->"address"::jsonb
+# output: data->'address'::jsonb
 print(nested)
 
 # Nested access
 nested = jf['address']['city']
-# output: data->"address"->"city"::jsonb
+# output: data->'address'->'city'::jsonb
 print(nested)
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-psycopg2-binary>=2.9.2
-toml>=0.10.1
-setuptools>=75.6.0
-
+psycopg2-binary>=2.9.12
+toml>=0.10.2
+setuptools>=82.0.1

--- a/rick_db/cli/commands/dto.py
+++ b/rick_db/cli/commands/dto.py
@@ -96,11 +96,14 @@ class Command(BaseCommand):
         name = re.sub(r"[^a-zA-Z0-9]", "", name)
         if not name or not name[0].isalpha():
             name = "T" + name
-        line = ["tablename='{name}'".format(name=table_name)]
+        # interpolated identifiers come from database introspection and may
+        # contain quotes; emit them as Python string literals via repr() so a
+        # crafted table/column name cannot break out and inject code
+        line = ["tablename={name}".format(name=repr(table_name))]
         if schema is not None:
-            line.append("schema='{schema}'".format(schema=schema))
+            line.append("schema={schema}".format(schema=repr(schema)))
         if pk is not None:
-            line.append("pk='{pk}'".format(pk=pk))
+            line.append("pk={pk}".format(pk=repr(pk)))
 
         result.append("@fieldmapper({fields})".format(fields=", ".join(line)))
         result.append("class {name}Record:".format(name=name))
@@ -110,8 +113,17 @@ class Command(BaseCommand):
             if f.primary:
                 if not has_id:
                     attr_name = "id"
+            # the attribute name is emitted as a bare Python identifier; reject
+            # anything that is not a valid identifier rather than produce broken
+            # or injectable output
+            if not attr_name.isidentifier():
+                raise ValueError(
+                    "cannot generate DTO: field name '{}' is not a valid Python identifier".format(
+                        attr_name
+                    )
+                )
             result.append(
-                "    {attr} = '{field}'".format(attr=attr_name, field=f.field)
+                "    {attr} = {field}".format(attr=attr_name, field=repr(f.field))
             )
 
         result.append("")

--- a/rick_db/sql/common.py
+++ b/rick_db/sql/common.py
@@ -50,7 +50,8 @@ class JsonField:
         if self.dialect and self.dialect.json_support:
             expr = self.dialect.json_extract(self.field_name, path, alias)
             return Literal(expr)
-        return Literal(f"JSON_EXTRACT({self.field_name}, '{path}')")
+        escaped = str(path).replace("'", "''")
+        return Literal(f"JSON_EXTRACT({self.field_name}, '{escaped}')")
 
     def extract_text(self, path, alias=None):
         """
@@ -63,7 +64,8 @@ class JsonField:
         if self.dialect and self.dialect.json_support:
             expr = self.dialect.json_extract_text(self.field_name, path, alias)
             return Literal(expr)
-        return Literal(f"JSON_EXTRACT({self.field_name}, '{path}')")
+        escaped = str(path).replace("'", "''")
+        return Literal(f"JSON_EXTRACT({self.field_name}, '{escaped}')")
 
     def contains(self, value):
         """
@@ -91,7 +93,8 @@ class JsonField:
         if self.dialect and self.dialect.json_support:
             expr = self.dialect.json_contains_path(self.field_name, path)
             return Literal(expr)
-        return Literal(f"JSON_CONTAINS_PATH({self.field_name}, 'one', '{path}')")
+        escaped = str(path).replace("'", "''")
+        return Literal(f"JSON_CONTAINS_PATH({self.field_name}, 'one', '{escaped}')")
 
     def __str__(self):
         return self.field_name
@@ -108,7 +111,8 @@ class JsonField:
         if self.dialect and self.dialect.json_support:
             expr = self.dialect.json_extract(self.field_name, key)
             return JsonField(expr, self.dialect)
-        field_path = f"JSON_EXTRACT({self.field_name}, '$.{key}')"
+        escaped = str(key).replace("'", "''")
+        field_path = f"JSON_EXTRACT({self.field_name}, '$.{escaped}')"
         return JsonField(field_path, self.dialect)
 
 
@@ -178,10 +182,13 @@ class PgJsonField(JsonField):
 
         Example:
             json_field = PgJsonField('data')
-            json_field['name']  # Returns an object representing data->"name"
+            json_field['name']  # Returns an object representing data->'name'
         """
-        # For PostgreSQL we use -> which preserves the JSON type
-        field_path = f'{self.field_name}->"{key}"'
+        # For PostgreSQL we use -> which preserves the JSON type. The key is a
+        # string literal (single-quoted), with embedded quotes escaped; double
+        # quotes would be parsed as an identifier reference, not a JSON key.
+        key_str = str(key).replace("'", "''")
+        field_path = f"{self.field_name}->'{key_str}'"
         result = PgJsonField(field_path, self.dialect, self.is_jsonb)
         return result
 

--- a/rick_db/sql/dialect.py
+++ b/rick_db/sql/dialect.py
@@ -48,6 +48,18 @@ class SqlDialect:
         escaped = identifier.replace('"', '""')
         return f'"{escaped}"'
 
+    @staticmethod
+    def _quote_str(value):
+        """
+        Quote a value as a SQL string literal, escaping embedded single quotes by
+        doubling them (SQL standard). Used for non-parameterizable fragments such
+        as JSON paths, where the value is interpolated directly into the SQL text.
+
+        :param value: value to quote
+        :return: quoted string literal, e.g. "'$.name'"
+        """
+        return "'" + str(value).replace("'", "''") + "'"
+
     def table(self, table_name, alias=None, schema=None):
         """
         Quotes a table name
@@ -187,7 +199,7 @@ class SqlDialect:
             and not path.startswith("'")
             and not path.startswith('"')
         ):
-            path = f"'{path}'"
+            path = self._quote_str(path)
 
         expr = self._json_extract.format(field=field_expr, path=path)
 
@@ -219,7 +231,7 @@ class SqlDialect:
             and not path.startswith("'")
             and not path.startswith('"')
         ):
-            path = f"'{path}'"
+            path = self._quote_str(path)
 
         expr = self._json_extract_text.format(field=field_expr, path=path)
 
@@ -276,7 +288,7 @@ class SqlDialect:
             and not path.startswith("'")
             and not path.startswith('"')
         ):
-            path = f"'{path}'"
+            path = self._quote_str(path)
 
         expr = self._json_contains_path.format(field=field_expr, path=path)
 
@@ -386,7 +398,7 @@ class PgSqlDialect(SqlDialect):
             if path.startswith("$."):
                 path = path[2:]
             path = path.strip("'\"")
-            return f"'{path}'"
+            return self._quote_str(path)
         return str(path)
 
     def json_extract(self, field, path, alias=None):
@@ -479,7 +491,7 @@ class PgSqlDialect(SqlDialect):
         field_expr = self._json_field_expr(field)
 
         if not path.startswith("'"):
-            path = f"'{path}'"
+            path = self._quote_str(path)
 
         expr = f"{field_expr}::jsonb @? {path}"
 
@@ -547,7 +559,7 @@ class ClickHouseSqlDialect(SqlDialect):
             if path.startswith("$."):
                 path = path[2:]
             path = path.strip("'\"")
-            return f"'{path}'"
+            return self._quote_str(path)
         return str(path)
 
     def json_extract(self, field, path, alias=None):

--- a/rick_db/version.py
+++ b/rick_db/version.py
@@ -1,4 +1,4 @@
-RICK_DB_VERSION = ["2", "2", "2"]
+RICK_DB_VERSION = ["2", "2", "4"]
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,9 +31,9 @@ packages = find:
 include_package_data = true
 zip_safe = false
 install_requires =
-    psycopg2>=2.9.11
-    toml>=0.10.1
-    setuptools>=75.6.0
+    psycopg2>=2.9.12
+    toml>=0.10.2
+    setuptools>=82.0.1
 
 [options.entry_points]
 console_scripts =

--- a/tests/sql/test_json_fields.py
+++ b/tests/sql/test_json_fields.py
@@ -68,6 +68,10 @@ class TestBaseSqlDialectJson:
         result = self.dialect.json_contains_path("data", "'$.name'")
         assert result == "JSON_CONTAINS_PATH(\"data\", 'one', '$.name')"
 
+    def test_json_extract_escapes_single_quotes(self):
+        result = self.dialect.json_extract("data", "a' OR '1'='1")
+        assert result == "JSON_EXTRACT(\"data\", 'a'' OR ''1''=''1')"
+
 
 class TestSqlDialectFieldErrors:
     """Test SqlDialect.field() and database() error/edge branches"""
@@ -185,6 +189,10 @@ class TestPgSqlDialectJson:
     def test_json_extract_table_qualified(self):
         result = self.dialect.json_extract("t.data", "name")
         assert result == '"t"."data"->>\'name\''
+
+    def test_json_extract_escapes_single_quotes(self):
+        result = self.dialect.json_extract("data", "a' OR '1'='1")
+        assert result == "\"data\"->>'a'' OR ''1''=''1'"
 
     def test_json_extract_literal(self):
         result = self.dialect.json_extract(Literal("my_func()"), "name")
@@ -331,7 +339,12 @@ class TestPgJsonField:
         jf = PgJsonField("data", self.dialect)
         result = jf["name"]
         assert isinstance(result, PgJsonField)
-        assert result.field_name == 'data->"name"'
+        assert result.field_name == "data->'name'"
+
+    def test_getitem_escapes_quotes(self):
+        jf = PgJsonField("data", self.dialect)
+        result = jf["a'b"]
+        assert result.field_name == "data->'a''b'"
 
     def test_str_jsonb(self):
         jf = PgJsonField("data", self.dialect, is_jsonb=True)


### PR DESCRIPTION
## Summary
- Escape JSON **path** arguments to prevent SQL injection: a new `SqlDialect._quote_str()` doubles embedded single quotes across all dialects, applied to `json_extract` / `json_extract_text` / `json_contains_path`, the PG `@?` path operator, and the `JsonField` / `PgJsonField` helpers. `PgJsonField['key']` now emits a single-quoted (escaped) JSON key (`data->'name'`) instead of a double-quoted identifier reference — also a correctness fix.
- Harden the `dto` generator (`cli/commands/dto.py`): database-derived identifiers are emitted via `repr()` and attribute names are validated with `isidentifier()`, so a crafted table/column name can't inject code into the generated module.
- Document the JSON-path interpolation caveat (`docs/json_operations.md`) and correct the `->` example outputs (`docs/classes/pgjsonfield.md`, `docs/json_operations.md`).
- Bump runtime dependency floors (`requirements.txt`, `setup.cfg`) and bump the package version to **2.2.4**, splitting the changelog so the testcontainers/CI work (already on `master`) and the security fixes are recorded under their respective sections.

## Notes
JSON paths are still interpolated, not parameterized — callers must continue to treat them as code and not build them from untrusted input. The escaping closes the injection vector; the docs make the contract explicit.

## Testing
- `pytest tests/sql/test_json_fields.py` → 78 passed (includes new quote-escaping assertions).
- Full suite (PostgreSQL + ClickHouse via testcontainers) → 849 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden JSON path handling and DTO code generation against injection vectors, update documentation to reflect the JSON path contract, and bump dependencies and version to 2.2.4.

Bug Fixes:
- Escape JSON path arguments across dialects and JSON helpers to prevent SQL injection via crafted paths or keys.
- Emit database-derived identifiers in generated DTO modules as safe Python string literals and reject invalid attribute names to avoid code injection in generated code.

Enhancements:
- Introduce a shared SQL string literal quoting helper for non-parameterizable fragments such as JSON paths.
- Align PostgreSQL JSON field access to use single-quoted JSON keys instead of double-quoted identifiers for correct operator behavior.

Build:
- Raise minimum versions for core runtime dependencies (psycopg2, toml, setuptools).

Documentation:
- Document the JSON path interpolation caveat and clarify that paths must not be built from untrusted input.
- Correct and update JSON field and PgJsonField examples to match the actual SQL output and quoting semantics.

Tests:
- Extend JSON field tests to cover escaping of single quotes in JSON paths and PostgreSQL JSON key access.

Chores:
- Update changelog structure to reflect the 2.2.4 release and previous CI/testing changes.
- Bump the library version to 2.2.4.