### PR TITLE
Bump publish workflow actions to v6 (Node 24)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,9 +13,9 @@ jobs:
       id-token: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 


### PR DESCRIPTION
Bump `actions/checkout@v4` → `@v6` and `actions/setup-python@v5` → `@v6` in `publish.yml` so the deploy workflow runs on Node.js 24 (Node 20 is deprecated). Matches the CI/SBOM workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Bump actions/checkout to v6 and actions/setup-python to v6 in the publish workflow to align with newer runtime support.